### PR TITLE
Validation contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,8 +1099,7 @@ So even though the invoice object didn't have any validation errors, the `#valid
 `false` because one of its owned line item object did have an error.
 
 Transis also supports validation contexts. Multiple contextual validations can be registered for the same attribute.
-Each contextual validation will executed depending on the context provided. It's important to note that all attributes
-without a registered context will execute regardless of the context provided.
+Contextual validations will only be applied when a matching context value is provided to the `Transis.Model.validate` method.
 
 ```javascript
 var Invoice = Transis.Model.extend('Invoice', function() {

--- a/README.md
+++ b/README.md
@@ -1116,7 +1116,7 @@ var Invoice = Transis.Model.extend('Invoice', function() {
 
 var invoice = new Invoice({name: 'foo'});
 console.log(invoice.validate());
-// true since there is no context provided
+// true
 console.log(invoice.validate('nameContext'));
 // false
 console.log(invoice.errors);

--- a/README.md
+++ b/README.md
@@ -1098,8 +1098,8 @@ console.log(invoice.errors);
 So even though the invoice object didn't have any validation errors, the `#validate` method returned
 `false` because one of its owned line item object did have an error.
 
-Transis also supports validation contexts. Multiple contextual validations can be registered for the same attribute.
-Contextual validations will only be applied when a matching context value is provided to the `Transis.Model.validate` method.
+Transis also supports validation contexts. Multiple contextual validations can be registered for the same attribute. Each contextual validation will executed depending on the context provided. Contextual validations will only be applied
+when a matching context value is provided to the `Transis.Model.validate` method.
 
 ```javascript
 var Invoice = Transis.Model.extend('Invoice', function() {

--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,31 @@ console.log(invoice.errors);
 So even though the invoice object didn't have any validation errors, the `#validate` method returned
 `false` because one of its owned line item object did have an error.
 
+Transis also supports validation contexts. Multiple contextual validations can be registered for the same attribute.
+Each contextual validation will executed depending on the context provided. It's important to note that all attributes
+without a registered context will execute regardless of the context provided.
+
+```javascript
+var Invoice = Transis.Model.extend('Invoice', function() {
+  this.attr('name', 'string');
+  this.hasMany('lineItems', 'LineItem');
+
+  this.validate('name', function() {
+    if (!this.name || this.name.length < 6) {
+      this.addError('name', 'must be at least 6 characters');
+    }
+  }, {on: 'nameContext'});
+});
+
+var invoice = new Invoice({name: 'foo'});
+console.log(invoice.validate());
+// true since there is no context provided
+console.log(invoice.validate('nameContext'));
+// false
+console.log(invoice.errors);
+// { name: [ 'must be at least 6 characters' ] }
+```
+
 ### React integration
 
 At Centro we use [React][React] to implement our views so we've created a small React mixin to make

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2758,16 +2758,18 @@ describe('Model', function () {
 
 
       describe('given a context', function() {
+        var contains = function(array, value) { return array.indexOf(value) >= 0 }
+
         it('runs only validators for the given property name that include the context', function() {
           var m = new ValidatedFoo({name: 'FOO', num: 34.3});
           m.validateAttr('name', 'nameContext');
-          expect(m.ownErrors.name).toEqual(['must be greater than 5 characters']);
+          expect( contains(m.ownErrors.name, 'must be greater than 5 characters') ).toBe(true);
         });
 
         it('runs validators for same attribute that do not have a context', function() {
           var m = new ValidatedFoo({name: 'FOO'});
           m.validateAttr('name', 'nameContext');
-          expect(m.ownErrors.name).toEqual([ 'must be lower case']);
+          expect( contains(m.ownErrors.name, 'must be lower case') ).toBe(true);
         });
 
         it('clears existing validation errors on the given property name', function() {

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2406,32 +2406,23 @@ describe('Model', function () {
         }
       });
 
-      this.validate('name', {
-        on: 'nameContext',
-        validator: function() {
+      this.validate('name', function() {
           if(this.name && this.name.length <= 5) {
             this.addError('name', 'must be greater than 5 characters');
           }
-        }
-      });
+        }, {on: 'nameContext'});
 
-      this.validate('name', {
-        on: 'contextNotUsed',
-        validator: function() {
+      this.validate('name', function() {
           if(this.name && this.name.length <= 5) {
             this.addError('name', 'error not used');
           }
-        }
-      });
+        }, {on: 'contextNotUsed'});
 
-      this.validate('num', {
-        on: 'maxNumContext',
-        validator: function() {
+      this.validate('num', function() {
           if(this.num > 10) {
             this.addError('num', 'exceeds maximum value for num')
           }
-        }
-      });
+      }, {on: 'maxNumContext'});
 
       this.validate('num', 'numIsInteger');
 
@@ -2459,14 +2450,11 @@ describe('Model', function () {
         }
       });
 
-      this.validate('x', {
-        on: 'maxNumContext',
-        validator: function() {
+      this.validate('x', function() {
           if(this.x > 10) {
             this.addError('x', 'exceeds maximum value for x')
           }
-        }
-      });
+      }, {on: 'maxNumContext'});
     });
 
     beforeEach(function() {

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2400,6 +2400,15 @@ describe('Model', function () {
         }
       });
 
+      this.validate('name', {
+        on: 'context',
+        validator: function() {
+          if(this.name && this.name.length <= 5) {
+            this.addError('name', 'must be greater than 5 characters');
+          }
+        }
+      });
+
       this.validate('num', 'numIsInteger');
 
       this.hasMany('bars', 'ValidatedBar', {owner: true});
@@ -2734,6 +2743,13 @@ describe('Model', function () {
         expect(m.ownErrors).toEqual({});
         m.validate();
         expect(m.ownErrors).toEqual({name: ['must be lower case'], num: ['is not an integer']});
+      });
+
+      it('runs validators for the given context', function() {
+        var m = new ValidatedFoo({name: 'Foo'});
+        expect(m.ownErrors).toEqual({});
+        m.validate('context');
+        expect(m.ownErrors).toEqual({name: ['must be greater than 5 characters']});
       });
 
       it('runs validate on owned associated models', function() {

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2761,7 +2761,13 @@ describe('Model', function () {
         it('runs only validators for the given property name that include the context', function() {
           var m = new ValidatedFoo({name: 'FOO', num: 34.3});
           m.validateAttr('name', 'nameContext');
-          expect(m.ownErrors.name).toEqual(['must be greater than 5 characters']);
+          expect(m.ownErrors.name).toEqual(['must be lower case', 'must be greater than 5 characters']);
+        });
+
+        it('runs validators for same attribute that do not have a context', function() {
+          var m = new ValidatedFoo({name: 'FOO'});
+          m.validateAttr('name', 'nameContext');
+          expect(m.ownErrors.name).toEqual([ 'must be lower case', 'must be greater than 5 characters']);
         });
 
         it('clears existing validation errors on the given property name', function() {
@@ -2769,7 +2775,7 @@ describe('Model', function () {
           m.addError('name', 'abc');
           expect(m.ownErrors.name).toEqual(['abc']);
           m.validateAttr('name', 'nameContext');
-          expect(m.ownErrors.name).toEqual(['must be greater than 5 characters']);
+          expect(m.ownErrors.name).toEqual(['must be lower case', 'must be greater than 5 characters']);
         });
 
         it('returns false when some validation fails', function() {
@@ -2799,7 +2805,7 @@ describe('Model', function () {
         expect(m.bars.at(0).ownErrors).toEqual({});
         expect(m.ownErrors).toEqual({});
         m.validate('maxNumContext');
-        expect(m.bars.at(0).ownErrors).toEqual({x: ['exceeds maximum value for x']});
+        expect(m.bars.at(0).ownErrors).toEqual({x: ['must be even', 'exceeds maximum value for x']});
         expect(m.ownErrors).toEqual({num: ['exceeds maximum value for num']});
       });
 
@@ -2857,7 +2863,7 @@ describe('Model', function () {
           var m = new ValidatedFoo({name: 'Foo', num: 3.4});
           expect(m.ownErrors).toEqual({});
           m.validate('nameContext');
-          expect(m.ownErrors).toEqual({name: ['must be greater than 5 characters'], num: ['is not an integer']});
+          expect(m.ownErrors).toEqual({name: ['must be lower case', 'must be greater than 5 characters'], num: ['is not an integer']});
         });
 
         it('runs all other validations without a context', function() {
@@ -2865,7 +2871,7 @@ describe('Model', function () {
           expect(m.ownErrors).toEqual({});
           m.validate('nameContext');
           expect(m.ownErrors).toEqual({
-            name: ['must be greater than 5 characters'],
+            name: ['must be lower case', 'must be greater than 5 characters'],
             withoutContext: ['maximum value exceeded']
           });
         });

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2761,13 +2761,13 @@ describe('Model', function () {
         it('runs only validators for the given property name that include the context', function() {
           var m = new ValidatedFoo({name: 'FOO', num: 34.3});
           m.validateAttr('name', 'nameContext');
-          expect(m.ownErrors.name).toEqual(['must be lower case', 'must be greater than 5 characters']);
+          expect(m.ownErrors.name).toEqual(['must be greater than 5 characters']);
         });
 
         it('runs validators for same attribute that do not have a context', function() {
           var m = new ValidatedFoo({name: 'FOO'});
           m.validateAttr('name', 'nameContext');
-          expect(m.ownErrors.name).toEqual([ 'must be lower case', 'must be greater than 5 characters']);
+          expect(m.ownErrors.name).toEqual([ 'must be lower case']);
         });
 
         it('clears existing validation errors on the given property name', function() {

--- a/src/model.js
+++ b/src/model.js
@@ -1056,8 +1056,8 @@ var Model = TransisObject.extend(function() {
   };
 
   // Public: Runs registered validators for the given attribute. This will clear any existing
-  // validation errors for the given attribute. The registered validators which are executed can be scoped
-  // by provided an optional context.
+  // validation errors for the given attribute. The registered validators can be scoped
+  // by providing an optional context.
   //
   // name - The name of the attribute to run validations for.
   // ctx  - The context in which to run validations on the given attribute. (optional)

--- a/src/model.js
+++ b/src/model.js
@@ -362,14 +362,14 @@ var Model = TransisObject.extend(function() {
   // the `Model#addError` method to record a validation error when one is detected.
   //
   // name - The name of the property to validate.
-  // f    - A validator function or the name of an instance method.
+  // f    - A validator function, the name of an instance method, or a context in which to validate.
   //
   // Returns the receiver.
-  this.validate = function(name, object) {
+  this.validate = function(name, f) {
     if (!this.prototype.hasOwnProperty('validators')) {
       this.prototype.validators = Object.create(this.prototype.validators);
     }
-    (this.prototype.validators[name] = this.prototype.validators[name] || []).push(object);
+    (this.prototype.validators[name] = this.prototype.validators[name] || []).push(f);
     return this;
   };
 
@@ -1056,9 +1056,11 @@ var Model = TransisObject.extend(function() {
   };
 
   // Public: Runs registered validators for the given attribute. This will clear any existing
-  // validation errors for the given attribute.
+  // validation errors for the given attribute. The registered validators which are executed can be scoped
+  // by provided an optional context.
   //
   // name - The name of the attribute to run validations for.
+  // ctx  - The context in which to run validations on the given attribute. (optional)
   //
   // Returns `true` if no validation errors are found on the given attribute and `false` otherwise.
   this.prototype.validateAttr = function(name, ctx) {
@@ -1084,6 +1086,8 @@ var Model = TransisObject.extend(function() {
 
   // Public: Runs all registered validators for all properties and also validates owned
   // associations.
+  //
+  // ctx - The context in which to run validations
   //
   // Returns `true` if no validation errors are found and `false` otherwise.
   this.prototype.validate = function(ctx) {

--- a/src/model.js
+++ b/src/model.js
@@ -1070,7 +1070,7 @@ var Model = TransisObject.extend(function() {
     this._clearErrors(name);
     if (!this.validators[name]) { return true; }
 
-    let validators = this.validators[name].filter( (v)=> !v.opts.on || v.opts.on === ctx );
+    const validators = this.validators[name].filter( (v)=> !v.opts.on || v.opts.on === ctx );
 
     for (let i = 0, n = validators.length; i < n; i++) {
       let validator = validators[i].validator;

--- a/src/model.js
+++ b/src/model.js
@@ -369,7 +369,9 @@ var Model = TransisObject.extend(function() {
     if (!this.prototype.hasOwnProperty('validators')) {
       this.prototype.validators = Object.create(this.prototype.validators);
     }
+
     (this.prototype.validators[name] = this.prototype.validators[name] || []).push(f);
+
     return this;
   };
 
@@ -1068,7 +1070,7 @@ var Model = TransisObject.extend(function() {
     if (!this.validators[name]) { return true; }
 
     let attrCtx = this.validators[name].find( (v)=> {return v.on && v.on === ctx} );
-    if(ctx && attrCtx) {
+    if(attrCtx) {
       attrCtx.validator.call(this);
     }
     else {

--- a/src/model.js
+++ b/src/model.js
@@ -1070,19 +1070,14 @@ var Model = TransisObject.extend(function() {
     this._clearErrors(name);
     if (!this.validators[name]) { return true; }
 
-    let attrCtx = ctx && this.validators[name].find( (v)=> {return v.opts.on && v.opts.on === ctx} );
-    if(attrCtx) {
-      attrCtx.validator.call(this);
-    }
-    else {
-      for (let i = 0, n = this.validators[name].length; i < n; i++) {
-        if (this.validators[name][i].opts.on) { continue; }
-        let validator = this.validators[name][i].validator;
+    let validators = this.validators[name].filter( (v)=> !v.opts.on || v.opts.on === ctx );
 
-        if (typeof validator === 'function') { validator.call(this); }
-        else if (typeof validator === 'string' && validator in this) { this[validator](); }
-        else { throw new Error(`${this.constructor}#validateAttr: don't know how to execute validator: \`${validator}\``); }
-      }
+    for (let i = 0, n = validators.length; i < n; i++) {
+      let validator = validators[i].validator;
+
+      if (typeof validator === 'function') { validator.call(this); }
+      else if (typeof validator === 'string' && validator in this) { this[validator](); }
+      else { throw new Error(`${this.constructor}#validateAttr: don't know how to execute validator: \`${validator}\``); }
     }
 
     return !(name in this.ownErrors);


### PR DESCRIPTION
Adds support for validation context that is backwards compatible with previous methods of validation.

For example a validation with context can be defined like this:
```
this.validate('name', {
  on: 'nameContext',
  validator: function() {
    if(this.name && this.name.length <= 5) {
      this.addError('name', 'must be greater than 5 characters');
    }
  }
});
```

And validation with context like this: 
``` 
model.validateAttr('name', 'nameContext');
model.validate('nameContext');
```


