### PR TITLE
Adds Transis.Object.clearChangeQueue and Transis.reset for cleaning up pending change notifications in specs.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,18 @@
 import TransisObject from "./object";
 import TransisArray from "./array";
 import Model from "./model";
+import IdMap from "./id_map";
 import * as react from "./react";
 import * as util from "./util";
 import * as parsers from "./parsers";
 import pluralize from "pluralize";
+
+// Public: Resets Transis by clearing the ID map and clearing out the pending change queue. This
+// should only ever be used in specs.
+function reset() {
+  IdMap.clear();
+  TransisObject.clearChangeQueue();
+}
 
 export default Object.assign({
   Object: TransisObject,
@@ -13,5 +21,6 @@ export default Object.assign({
   Model,
   pluralize,
   ReactPropsMixin: react.PropsMixin,
-  ReactStateMixin: react.StateMixin
+  ReactStateMixin: react.StateMixin,
+  reset: reset
 }, util, parsers);

--- a/src/object.js
+++ b/src/object.js
@@ -168,6 +168,14 @@ TransisObject.flush = function() {
   return this;
 };
 
+// Public: Clears the pending change queue. This should only be used in specs.
+TransisObject.clearChangeQueue = function() {
+  clearTimeout(flushTimer);
+  changedObjects = {};
+  delayCallbacks = [];
+  return this;
+};
+
 // Public: Register a callback to be invoked immediately after the next flush cycle completes.
 //
 // f - A function.


### PR DESCRIPTION
Call `Transis.reset` from you spec cleanup callbacks to ensure that the ID map and any pending change notifications are cleared.
