### PR TITLE
Gracefully handle create or update situations

### DIFF
--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -1867,6 +1867,28 @@ describe('Model', function () {
         a.load({id: 4, first: 'Bart', last: 'Simpson'});
       }).toThrow(new Error('Author#load: received attributes with id `4` but model already has id `3`'));
     });
+
+    it('loads the existing model instead of the new model when given an id that already exists in the id map', function() {
+      var a1 = Author.load({id: 12, first: 'Homer', last: 'Simpson'});
+      var a2 = new Author;
+
+      a2.load({id: 12, first: 'HOMER', last: 'SIMPSON'});
+
+      expect(a2.isNew).toBe(true);
+
+      expect(a1.first).toBe('HOMER');
+      expect(a1.last).toBe('SIMPSON');
+      expect(a1.isLoaded).toBe(true);
+    });
+
+    it('logs a warning when there is an existing model with the same id already in the id map', function() {
+      var a1 = Author.load({id: 12, first: 'Homer', last: 'Simpson'});
+      var a2 = new Author;
+
+      a2.load({id: 12, first: 'HOMER', last: 'SIMPSON'});
+
+      expect(console.warn).toHaveBeenCalledWith('Author#load: loading attributes that contain an id (12) that already exists in the identity map, the receiver will not be updated');
+    });
   });
 
   describe('change tracking', function() {

--- a/src/model.js
+++ b/src/model.js
@@ -945,6 +945,10 @@ var Model = TransisObject.extend(function() {
   // Public: Loads the given attributes into the model. This method simply ensure's that the
   // receiver has its `id` set and then delegates to `Model.load`.
   //
+  // If the given attributes have an `id` that already exists in the identity map, then this method
+  // will actually load the attributes onto the existing model instead of the receiver. This
+  // situation may occur when you have a create or update situation on the backend.
+  //
   // Returns the receiver.
   this.prototype.load = function(attrs) {
     var id = attrs.id;
@@ -957,9 +961,17 @@ var Model = TransisObject.extend(function() {
       throw new Error(`${this.constructor}#load: received attributes with id \`${id}\` but model already has id \`${this.id}\``);
     }
 
-    if (this.id == null) { this.id = id; }
+    if (this.id == null) {
+      if (!IdMap.get(this.constructor, id)) {
+        this.id = id;
+      }
+      else {
+        console.warn(`${this.constructor}#load: loading attributes that contain an id (${id}) that already exists in the identity map, the receiver will not be updated`);
+      }
+    }
 
-    attrs.id = this.id;
+    attrs.id = id || this.id;
+
     this.constructor.load(attrs);
 
     return this;


### PR DESCRIPTION
Several times now we've run into problems when we call `save` a `NEW` Transis model and the backend treats it as an update and returns the id of an existing record. If that id is already loaded into the Transis identity map, then an exception is raised. This PR handles that situation more gracefully by loading the response into the existing model instead of the `NEW` one.

This could still lead to some weirdness if you expect the `NEW` model to eventually reach the `LOADED` state but I feel that its better than just not handling this situation at all.