### PR TITLE
Allows parent classes to resolve subclasses when loading data.

### DIFF
--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2985,11 +2985,13 @@ describe('Model', function () {
       });
 
       it('throws an exception when there are no subclasses', function() {
-        expect(()=> Child.resolveSubclass('Grandchild')).toThrow(new Error('Child.resolveSubclass: Child does not have subclasses'));
+        expect(()=> Child.resolveSubclass('Grandchild'))
+          .toThrow(new Error('Child.resolveSubclass: could not find subclass Grandchild'));
       });
 
       it('throws an exception when the subclasses could not be found', function() {
-        expect(()=> Parent.resolveSubclass('SomethingElse')).toThrow(new Error('Parent.resolveSubclass: could not find subclass SomethingElse'));
+        expect(()=> Parent.resolveSubclass('SomethingElse'))
+          .toThrow(new Error('Parent.resolveSubclass: could not find subclass SomethingElse'));
       });
     });
 

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2958,25 +2958,17 @@ describe('Model', function () {
 
   describe('subclassing', function() {
     var Parent = Model.extend('Parent', function() {
-      this.prototype.init = ()=> {};
-
       this.getSubclass = function(attrs) {
         return attrs.type;
       };
     });
 
-    var Child = Parent.extend('Child', function() {
-      this.prototype.init = ()=> {};
-    });
-
-    var AnotherChild = Parent.extend('AnotherChild', function() {
-      this.prototype.init = ()=> {};
-    });
+    var Child = Parent.extend('Child');
+    var AnotherChild = Parent.extend('AnotherChild');
 
     var Composition = Model.extend('Composition', function() {
       this.hasMany('things', 'Parent');
     });
-
 
     describe('.resolveSubclass', function() {
       it('can resolve subclases', function() {
@@ -3015,6 +3007,7 @@ describe('Model', function () {
             }
           ]
         });
+
         expect(loaded.things[0] instanceof Child).toBe(true);
         expect(loaded.things[1] instanceof AnotherChild).toBe(true);
       });

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2955,4 +2955,81 @@ describe('Model', function () {
       }, 100);
     });
   });
+
+  describe('subclassing', function() {
+    var Parent = Model.extend('Parent', function() {
+      this.prototype.init = ()=> {};
+
+      this.getSubclass = function(attrs) {
+        return attrs.type;
+      };
+    });
+
+    var Child = Parent.extend('Child', function() {
+      this.prototype.init = ()=> {};
+    });
+
+    var AnotherChild = Parent.extend('AnotherChild', function() {
+      this.prototype.init = ()=> {};
+    });
+
+    var Composition = Model.extend('Composition', function() {
+      this.hasMany('things', 'Parent');
+    });
+
+
+    describe('.resolveSubclass', function() {
+      it('can resolve subclases', function() {
+        var subclass = Parent.resolveSubclass('Child');
+        expect(subclass).toBe(Child);
+      });
+
+      it('throws an exception when there are no subclasses', function() {
+        expect(()=> Child.resolveSubclass('Grandchild')).toThrow(new Error('Child.resolveSubclass: Child does not have subclasses'));
+      });
+
+      it('throws an exception when the subclasses could not be found', function() {
+        expect(()=> Parent.resolveSubclass('SomethingElse')).toThrow(new Error('Parent.resolveSubclass: could not find subclass SomethingElse'));
+      });
+    });
+
+    describe('loading subclasses', function() {
+      it('returns an instance of appropriate subclass', function() {
+        var loaded = Parent.load({id: 1, type: 'Child'});
+        expect(loaded instanceof Child).toBe(true);
+      });
+
+      it('loads associated subclasses', function() {
+        var loaded = Composition.load({
+          id: 1,
+          things: [
+            {
+              id: 'thing1',
+              type: 'Child'
+            },
+            {
+              id: 'thing2',
+              type: 'AnotherChild'
+            }
+          ]
+        });
+        expect(loaded.things[0] instanceof Child).toBe(true);
+        expect(loaded.things[1] instanceof AnotherChild).toBe(true);
+      });
+
+      it('rejects non subclasses', function() {
+        expect(()=> {
+          Composition.load({
+            id: 2,
+            things: [
+              {
+                id: 'randomThing1',
+                type: 'SomethingElse'
+              }
+            ]
+          });
+        }).toThrow();
+      })
+    });
+  });
 });

--- a/src/model.js
+++ b/src/model.js
@@ -184,8 +184,9 @@ var Model = TransisObject.extend(function() {
   };
 
   this.resolveSubclass = function(name) {
-    if(!this.subclasses) { throw new Error(`${this}.resolveSubclass: ${this} does not have subclasses`); }
-    if(this.subclasses.indexOf(name) < 0) { throw new Error(`${this}.resolveSubclass: could not find subclass ${name}`); }
+    if(!this.subclasses || this.subclasses.indexOf(name) < 0) {
+      throw new Error(`${this}.resolveSubclass: could not find subclass ${name}`);
+    }
 
     return resolve(name);
   };


### PR DESCRIPTION
This stores subclasses when a model is extended.

Providing a `getSubclass` function on the class allows the parent class to resolve a subclass to instantiate when loading.

```JavaScript
var Parent = Model.extend('Parent', function() {
  this.prototype.init = ()=> {};

  this.getSubclass = function(attrs) {
    return attrs.type;
  };
});

var Child = Parent.extend('Child', function() {
  this.prototype.init = ()=> {};
});

var AnotherChild = Parent.extend('AnotherChild', function() {
  this.prototype.init = ()=> {};
});

var Composition = Model.extend('Composition', function() {
  this.hasMany('things', 'Parent');
});

var compostion = Composition.load({
  id: 1,
  things: [
    {
      id: 'thing1',
      type: 'Child'
    },
    {
      id: 'thing2',
      type: 'AnotherChild'
    }
  ]
});

composition.things[0] instanceof Child;
// true

composition.things[1] instanceof AnotherChild;
// true
```