### PR TITLE
Update undoChanges method to accept an only option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,7 +1000,11 @@ If we also make changes directly to the owner object, those changes are also lis
 object.
 
 Finally we can see that by calling `undoChanges` on the invoice, we also undo any changes on its
-owned line items
+owned line items.
+
+Note: `undoChanges` can be scoped using the options `only` and `except` by providing a string or array of names.
+      `invoice.undoChanges({only: 'lineItems'}));` Only undoes changes for lineItems and ignores the `name` attribute.
+      `invoice.undoChanges({except: 'lineItems'}));` Undoes all changes except for the `lineItems` assocation.
 
 In addition to tracking attribute changes, Transis will also track changes made to `hasMany`
 associations. So adding or removing an object from a `hasMany` array can also be undone:

--- a/README.md
+++ b/README.md
@@ -1003,8 +1003,8 @@ Finally we can see that by calling `undoChanges` on the invoice, we also undo an
 owned line items.
 
 Note: `undoChanges` can be scoped using the options `only` and `except` by providing a string or array of names.
-      `invoice.undoChanges({only: 'lineItems'}));` Only undoes changes for lineItems and ignores the `name` attribute.
-      `invoice.undoChanges({except: 'lineItems'}));` Undoes all changes except for the `lineItems` assocation.
+* `invoice.undoChanges({only: 'lineItems'}));` Only undoes changes for lineItems and ignores the `name` attribute.
+* `invoice.undoChanges({except: 'lineItems'}));` Undoes all changes except for the `lineItems` assocation.
 
 In addition to tracking attribute changes, Transis will also track changes made to `hasMany`
 associations. So adding or removing an object from a `hasMany` array can also be undone:

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2143,9 +2143,10 @@ describe('Model', function () {
       });
 
       it('does not undo changes to owned associations specified in the exception option as an array', function() {
-        this.invoice.billingAddress.name = 'Bob Smith';
-        this.invoice.undoChanges({except: ['billingAddress']});
-        expect(this.invoice.billingAddress.name).toBe('Bob Smith');
+        expect(this.invoice.lineItems.length).toBe(3);
+        this.invoice.lineItems.pop();
+        this.invoice.undoChanges({except: ['lineItems']});
+        expect(this.invoice.lineItems.length).toBe(2);
       });
 
       it('undoes only the assocations specified in the only option as an array', function() {

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -2126,19 +2126,37 @@ describe('Model', function () {
       });
 
       it('does not undo changes to the owned association specified in the except option as a string', function() {
-        var li = this.invoice.lineItems.at(0);
-
         this.invoice.billingAddress.name = 'Bob Smith';
         this.invoice.undoChanges({except: 'billingAddress'});
         expect(this.invoice.billingAddress.name).toBe('Bob Smith');
       });
 
-      it('does not undo changes to owned associations specified in the exception option as an array', function() {
-        var li = this.invoice.lineItems.at(0);
+      it('undoes only the assocations specified in the only option as a string', function() {
+        this.invoice.lineItems.pop();
+        expect(this.invoice.lineItems.length).toEqual(2);
+        this.invoice.billingAddress.name = "Tom Smith";
 
+        this.invoice.undoChanges({only: 'lineItems'});
+
+        expect(this.invoice.billingAddress.name).toBe('Tom Smith');
+        expect(this.invoice.lineItems.length).toEqual(3);
+      });
+
+      it('does not undo changes to owned associations specified in the exception option as an array', function() {
         this.invoice.billingAddress.name = 'Bob Smith';
         this.invoice.undoChanges({except: ['billingAddress']});
         expect(this.invoice.billingAddress.name).toBe('Bob Smith');
+      });
+
+      it('undoes only the assocations specified in the only option as an array', function() {
+        this.invoice.lineItems.pop();
+        expect(this.invoice.lineItems.length).toEqual(2);
+        this.invoice.billingAddress.name = 'Tom Smith';
+
+        this.invoice.undoChanges({only: ['lineItems']});
+
+        expect(this.invoice.billingAddress.name).toBe('Tom Smith');
+        expect(this.invoice.lineItems.length).toEqual(3);
       });
 
       it('re-runs validations', function() {

--- a/src/model.js
+++ b/src/model.js
@@ -1031,10 +1031,10 @@ var Model = TransisObject.extend(function() {
   // loaded.
   //
   // opts - An object containing zero or more of the following keys:
-  //   except - Either a string or an array of strings of owned association names to skip over when
-  //            undoing changes on owned associations.
-  //   only -   Either a string or an array of strings of owned association names that limit the undoing of changes
-  //            to only the provided associations.
+  //   except - Either a string or an array of strings of attributes or owned association names to skip over when
+  //            undoing changes.
+  //   only -   Either a string or an array of strings of attributes or owned association names that limit the undoing of changes
+  //            to only the provided names.
   //
   // Returns the receiver.
   this.prototype.undoChanges = function(opts = {}) {

--- a/src/model.js
+++ b/src/model.js
@@ -1033,6 +1033,8 @@ var Model = TransisObject.extend(function() {
   // opts - An object containing zero or more of the following keys:
   //   except - Either a string or an array of strings of owned association names to skip over when
   //            undoing changes on owned associations.
+  //   only -   Either a string or an array of strings of owned association names that limit the undoing of changes
+  //            to only the provided associations.
   //
   // Returns the receiver.
   this.prototype.undoChanges = function(opts = {}) {
@@ -1058,6 +1060,9 @@ var Model = TransisObject.extend(function() {
         if (!desc.owner) { continue; }
         if (opts.except === name) { continue; }
         if (Array.isArray(opts.except) && opts.except.indexOf(name) >= 0) { continue; }
+
+        if (opts.only && opts.only !== name) { continue; }
+        if (Array.isArray(opts.only) && opts.only.indexOf(name) === -1) { continue; }
 
         if (desc.type === 'hasOne') {
           this[name] && this[name].undoChanges();


### PR DESCRIPTION
The only option is either a string or an array of strings of owned
association names that limit the undoing of changes to only the
provided associations.