### PR TITLE
Optimize flush

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -50,7 +50,7 @@ function didChange(object, name) {
 
   (object.__changedProps__ = object.__changedProps__ || {})[name] = true;
   changedObjects[object.objectId] = object;
-  uncache.call(object, name);
+  if (object.__cache__) { delete object.__cache__[name]; }
 
   if (object.__deps__) {
     let deps = object.__deps__[name];
@@ -102,12 +102,6 @@ function flush() {
   let f;
   while ((f = delayCallbacks.shift())) { f(); }
 }
-
-// Internal: Caches the given name/value pair on the receiver.
-function cache(name, value) { (this.__cache__ = this.__cache__ || {})[name] = value; }
-
-// Internal: Removes the given name from the cache.
-function uncache(name) { if (this.__cache__) { delete this.__cache__[name]; } }
 
 // Internal: Indicates whether the current name has a value cached.
 function isCached(name) { return this.__cache__ ? this.__cache__.hasOwnProperty(name) : false; }
@@ -412,7 +406,7 @@ TransisObject.prototype._getProp = function(name) {
 
   value = (value === undefined) ? desc.default : value;
 
-  if (desc.cache) { cache.call(this, name, value); }
+  if (desc.cache) { (this.__cache__ = this.__cache__ || {})[name] = value; }
 
   return value;
 };

--- a/src/object.js
+++ b/src/object.js
@@ -72,27 +72,22 @@ function didChange(object, name) {
 // flush, regardless of how many of their dependent props have changed. Additionaly, cached values
 // are cleared where appropriate.
 function flush() {
-  var ids = Object.keys(changedObjects), f;
-
-  for (let j = 0, m = ids.length; j < m; j++) {
-    let object  = changedObjects[ids[j]];
-    let changes = Object.keys(object.__changedProps__);
-
-    for (let i = 0, n = changes.length; i < n; i++) {
-      didChange(object, changes[i]);
+  for (let id in changedObjects) {
+    for (let k in changedObjects[id].__changedProps__) {
+      didChange(changedObjects[id], k);
     }
   }
 
   for (let id in changedObjects) {
     let object  = changedObjects[id];
-    let changes = Object.keys(object.__changedProps__);
+    let changes = object.__changedProps__;
     let star    = false;
 
     object.__changedProps__ = {};
 
-    for (let i = 0, n = changes.length; i < n; i++) {
-      if (changes[i].indexOf('.') === -1) { star = true; }
-      object.notify(changes[i]);
+    for (let k in changes) {
+      if (k.indexOf('.') === -1) { star = true; }
+      object.notify(k);
     }
 
     if (star) { object.notify('*'); }
@@ -102,7 +97,8 @@ function flush() {
 
   flushTimer = null;
 
-  while (f = delayCallbacks.shift()) { f(); }
+  let f;
+  while ((f = delayCallbacks.shift())) { f(); }
 }
 
 // Internal: Caches the given name/value pair on the receiver.


### PR DESCRIPTION
When dealing with a large number of property changes (via a `load` of a lot of data for example) flushing changes to dependent properties and proxy objects was pretty inefficient. This PR aims to optimize that code.

The following changes were made:

1. Avoid processing the same object/name pair more than once (this easily let to the largest speedup).
1. Converted the function that processes dependencies to be iterative instead of recursive, thereby eliminating a large number of function calls.
1. Inlined the function to clear cached values, further reducing the number of function calls.