### PR TITLE
Add instrumentation support.

### DIFF
--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -74,7 +74,6 @@ describe('Model', function () {
     this.hasMany('as', 'CircularA', {inverse: 'bs', owner: true});
   });
 
-
   beforeEach(function() {
     BasicModel.mapper = TestMapper;
   });
@@ -3044,6 +3043,66 @@ describe('Model', function () {
           });
         }).toThrow();
       })
+    });
+  });
+
+  describe('instrument', function() {
+    beforeEach(function() {
+      this.post = new Post;
+    });
+
+    afterEach(function() {
+      Model.instrument.stop();
+    });
+
+    describe('start', function() {
+      beforeEach(function() {
+        Model.instrument.start();
+      });
+
+      it('records attr gets', function() {
+        this.post.title;
+        this.post.title;
+        this.post.body;
+        this.post.body;
+        this.post.body;
+        expect(Model.instrument.getLast().attrs['Post#title']).toBe(2);
+        expect(Model.instrument.getLast().attrs['Post#body']).toBe(3);
+      });
+
+      it('records hasOne gets', function() {
+        this.post.author;
+        this.post.author;
+        this.post.author;
+        this.post.author;
+        expect(Model.instrument.getLast().associations['Post#author']).toBe(4);
+      });
+
+      it('records hasMany gets', function() {
+        this.post.tags;
+        this.post.tags;
+        expect(Model.instrument.getLast().associations['Post#tags']).toBe(2);
+      });
+    });
+
+    describe('stop', function() {
+      beforeEach(function() {
+        Model.instrument.start();
+        this.post.title;
+        this.post.body;
+        Model.instrument.stop();
+      });
+
+      it('stops recording get', function() {
+        expect(Model.instrument.getLast().attrs['Post#title']).toBe(1);
+        expect(Model.instrument.getLast().attrs['Post#body']).toBe(1);
+        this.post.title;
+        this.post.title;
+        this.post.body;
+        this.post.body;
+        expect(Model.instrument.getLast().attrs['Post#title']).toBe(1);
+        expect(Model.instrument.getLast().attrs['Post#body']).toBe(1);
+      });
     });
   });
 });


### PR DESCRIPTION
Adds basic `Transis.Model` instrumentation support. Instrumenting records all attr and association gets. This can be useful to get a better sense of the data requirements of your views.

Begin instrumentation by running `Transis.Model.instrument.start()` and stop it by running `Transis.Model.instrument.stop()`. Then you can use `Transis.Model.instrument.print()` to get something that looks like this: 

![screen shot 2016-04-04 at 9 22 34 am](https://cloud.githubusercontent.com/assets/4668/14251075/d112df82-fa46-11e5-92dd-be34e61a0359.png)
