### PR TITLE
Simple benchmark to measure overhead on Transis Model attribute access

### DIFF
--- a/bench/model_attr_access.html
+++ b/bench/model_attr_access.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv='Content-type' content='text/html; charset=utf-8'>
+    <title>Transis Model Attribute Access</title>
+  </head>
+  <body>
+    <script src="../dist/transis.js"></script>
+    <script src="./model_attr_access_browser.js"></script>
+  </body>
+</html>

--- a/bench/model_attr_access.js
+++ b/bench/model_attr_access.js
@@ -17,10 +17,7 @@ const BENCH_TYPE = process.env.BENCH_TYPE;
 console.log('BENCH_TYPE', BENCH_TYPE);
 
 const BasicModel = transis.Model.extend('BasicModel', function() {
-  this.attr('str', 'string');
-  this.attr('strWithDefault', 'string', {default: 'zzz'});
   this.attr('num', 'number');
-  this.attr('date', 'date');
 });
 
 const makeObj =

--- a/bench/model_attr_access.js
+++ b/bench/model_attr_access.js
@@ -1,0 +1,62 @@
+'use strict';
+/*
+
+This benchmark compares the time it takes to access a Transis Model attribute vs
+a POJO property.
+
+Run benchmark from project root:
+
+> BENCH_TYPE=obj node --allow-natives-syntax bench/model_attr_access.js
+> BENCH_TYPE=model node --allow-natives-syntax bench/model_attr_access.js
+
+*/
+
+const transis = require('../dist');
+const BENCH_TYPE = process.env.BENCH_TYPE;
+
+console.log('BENCH_TYPE', BENCH_TYPE);
+
+const BasicModel = transis.Model.extend('BasicModel', function() {
+  this.attr('str', 'string');
+  this.attr('strWithDefault', 'string', {default: 'zzz'});
+  this.attr('num', 'number');
+  this.attr('date', 'date');
+});
+
+const makeObj =
+  BENCH_TYPE==='model'
+    ? (() => new BasicModel({num: 10}))
+    : (() => ({num: 10}))
+
+const benchmark = (m)=> m.num
+
+function runBenchmark(){
+  const model = makeObj();
+  let total = 0;
+  let i = 0;
+
+  // Use the result (sum), otherwise V8 optimizes the function call out! DCE FTW!
+  for(; i<10000000; ++i) {
+    total += benchmark(model);
+  }
+
+  return total;
+}
+
+// Allow v8 to collect type information
+runBenchmark();
+runBenchmark();
+
+// Optimize benchmark function to ensure performance numbers are stable
+// Otherwise, numbers may fluctuate because compiling and optimizing may or may not
+// happen during the benchmark.
+%OptimizeFunctionOnNextCall(benchmark);
+runBenchmark();
+
+// Run Benchmark
+const start = Date.now();
+const runitTotal = runBenchmark();
+console.log(`${Date.now() - start} ms`);
+
+// SANITY CHECK: Print out number and verify it matches expected result
+console.log('total', runitTotal, runitTotal === 1000000000);

--- a/bench/model_attr_access.js
+++ b/bench/model_attr_access.js
@@ -56,4 +56,4 @@ const runitTotal = runBenchmark();
 console.log(`${Date.now() - start} ms`);
 
 // SANITY CHECK: Print out number and verify it matches expected result
-console.log('total', runitTotal, runitTotal === 1000000000);
+console.log('total', runitTotal, runitTotal === 100000000);

--- a/bench/model_attr_access.js
+++ b/bench/model_attr_access.js
@@ -16,14 +16,35 @@ const BENCH_TYPE = process.env.BENCH_TYPE;
 
 console.log('BENCH_TYPE', BENCH_TYPE);
 
-const BasicModel = transis.Model.extend('BasicModel', function() {
+
+const TransisModel = transis.Model.extend('TransisModel', function() {
   this.attr('num', 'number');
 });
 
+
+const JSModel = function(obj) {
+  this._num = obj.num;
+}
+
+Object.defineProperty(JSModel.prototype, 'num', {
+  get() { return this._num; }
+});
+
+
+class ClassModel {
+  constructor(obj) {
+    this._num = obj.num;
+  }
+  get num() { return this._num; }
+}
+
+
 const makeObj =
-  BENCH_TYPE==='model'
-    ? (() => new BasicModel({num: 10}))
-    : (() => ({num: 10}))
+    BENCH_TYPE === 'model' ? () => new TransisModel({num: 10})
+  : BENCH_TYPE === 'proto' ? () => new JSModel({num: 10})
+  : BENCH_TYPE === 'class' ? () => new ClassModel({num: 10})
+  : BENCH_TYPE === 'obj'   ? () => ({ get num(){ return 10; } })
+  : null;
 
 const benchmark = (m)=> m.num
 

--- a/bench/model_attr_access_browser.js
+++ b/bench/model_attr_access_browser.js
@@ -1,0 +1,68 @@
+'use strict';
+/*
+
+This benchmark compares the time it takes to access a Transis Model attribute vs
+a POJO property.  This benchmark is meant to be run in the browser.
+
+file:///.../bench/model_attr_access.html#model
+file:///.../bench/model_attr_access.html#proto
+file:///.../bench/model_attr_access.html#class
+file:///.../bench/model_attr_access.html#obj
+
+*/
+
+var BENCH_TYPE = window.location.hash.slice(1);
+
+console.log('BENCH_TYPE', BENCH_TYPE);
+
+var TransisModel = Transis.Model.extend('TransisModel', function() {
+  this.attr('num', 'number');
+});
+
+
+var JSModel = function(obj) {
+  this._num = obj.num;
+}
+
+Object.defineProperty(JSModel.prototype, 'num', {
+  get() { return this._num; }
+});
+
+
+class ClassModel {
+  constructor(obj) {
+    this._num = obj.num;
+  }
+  get num() { return this._num; }
+}
+
+
+var makeObj =
+    BENCH_TYPE === 'model' ? function(){ return new TransisModel({num: 10});   }
+  : BENCH_TYPE === 'proto' ? function(){ return new JSModel({num: 10});        }
+  : BENCH_TYPE === 'class' ? function(){ return new ClassModel({num: 10});     }
+  : BENCH_TYPE === 'obj'   ? function(){ return ({ get num(){ return 10; } }); }
+  : null;
+
+var benchmark = function(m){ return m.num; }
+
+function runBenchmark(){
+  var model = makeObj();
+  var total = 0;
+  var i = 0;
+
+  // Use the result (sum), otherwise V8 optimizes the function call out! DCE FTW!
+  for(; i<10000000; ++i) {
+    total += benchmark(model);
+  }
+
+  return total;
+}
+
+// Run Benchmark
+var start = Date.now();
+var runitTotal = runBenchmark();
+console.log(`${Date.now() - start} ms`);
+
+// SANITY CHECK: Print out number and verify it matches expected result
+console.log('total', runitTotal, runitTotal === 100000000);


### PR DESCRIPTION
Compares the performance difference between  `myTransisModel.myAttr` vs `myPOJO.myProp`.

This PR is not meant to be merged, but as a conversation starter for:
1) General: How can we track performance?
2) Model Attr/Prop specific: Given the results below, anything we should do about this ?

```
> BENCH_TYPE=obj node --allow-natives-syntax bench/model_attr_access.js
BENCH_TYPE obj
94 ms
total 100000000 true
```

```
> BENCH_TYPE=model node --allow-natives-syntax bench/model_attr_access.js
BENCH_TYPE model
1839 ms
total 100000000 true
```

/cc @burrows 
