### PR TITLE
Update Model.buildQuery to accept options.

### DIFF
--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -949,6 +949,18 @@ describe('Model', function () {
         expect(QueryTest.mapper.query).toHaveBeenCalledWith({foo: 9, bar: 'baz'});
       });
 
+      it('passes the options passed to the buildQuery method to the mapper', function() {
+        const a = QueryTest.buildQuery({a: 1, b: 2});
+        a.query();
+        expect(QueryTest.mapper.query).toHaveBeenCalledWith({a: 1, b: 2});
+      });
+
+      it('merges the given options to the options passed to buildQuery', function() {
+        const a = QueryTest.buildQuery({a: 1, b: 2});
+        a.query({b: 3, c: 4});
+        expect(QueryTest.mapper.query).toHaveBeenCalledWith({a: 1, b: 3, c: 4});
+      });
+
       it('sets the isBusy property', function() {
         expect(this.a.isBusy).toBe(false);
         this.a.query();

--- a/src/model.js
+++ b/src/model.js
@@ -535,8 +535,12 @@ var Model = TransisObject.extend(function() {
   //
   //   Returns a new `Promise` that is resolved to the return value of the callback if it is called.
   //
+  // baseOpts - An object to pass along to the mapper method when the query is executed with the
+  //            `#query` method. Any options passed to the `#query` method will be merged in with
+  //            the options given here (default: `{}`).
+  //
   // Returns a new `Transis.Array` decorated with the properties and methods described above.
-  this.buildQuery = function() {
+  this.buildQuery = function(baseOpts = {}) {
     var modelClass = this, promise = Promise.resolve(), a = TransisArray.of(), queued;
 
     a.props({
@@ -546,7 +550,9 @@ var Model = TransisObject.extend(function() {
       meta: {}
     });
 
-    a.query = function(opts = {}) {
+    a.query = function(queryOpts = {}) {
+      const opts = Object.assign({}, baseOpts, queryOpts);
+
       if (this.isBusy) {
         if (!queued) {
           promise = promise.then(() => {


### PR DESCRIPTION
This PR updates the `Model.buildQuery` method to take in an options object. That object is then forwarded on to the mapper when the `#query` method is called. If the `#query` method also receives an options object, it is merged with the options passed to `buildQuery`. This lets you setup a complicated query with options once, an then re-fetch it over and over by simply calling `query` with no arguments.