### PR TITLE
Allow for using a function to return the default value of a prop.

### DIFF
--- a/spec/object_spec.js
+++ b/spec/object_spec.js
@@ -17,6 +17,10 @@ describe('Transis.Object', function() {
     this.prop('def', {
       default: 'hello'
     });
+
+    this.prop('funcDef', {
+      default: function() { return []; }
+    });
   });
 
   describe('.extend', function() {
@@ -108,6 +112,25 @@ describe('Transis.Object', function() {
           expect(t.def).toBe('hello');
           t.def = 'goodbye';
           expect(t.def).toBe('goodbye');
+        });
+      });
+
+      describe('with a function as the default option', function() {
+        it('returns the value of calling the function', function() {
+          expect(t.funcDef).toEqual([]);
+        });
+
+        it('invokes the function once per instance', function() {
+          var t2 = new Test;
+          expect(t.funcDef).toBe(t.funcDef);
+          expect(t2.funcDef).toBe(t2.funcDef);
+          expect(t2.funcDef).not.toBe(t.funcDef);
+        });
+
+        it('returns the set value', function() {
+          expect(t.funcDef).toEqual([]);
+          t.funcDef = ['foo'];
+          expect(t.funcDef).toEqual(['foo']);
         });
       });
 

--- a/src/object.js
+++ b/src/object.js
@@ -421,6 +421,21 @@ TransisObject.prototype._getProp = function(name) {
     value = this[`__${name}`];
   }
 
+  if (value === undefined) {
+    if (typeof desc.default === 'function') {
+      let defaultName = `__${name}_default`;
+
+      if (!(defaultName in this)) {
+        this[defaultName] = desc.default();
+      }
+
+      value = this[defaultName];
+    }
+    else {
+      value = desc.default;
+    }
+  }
+
   value = (value === undefined) ? desc.default : value;
 
   if (desc.cache) { (this.__cache__ = this.__cache__ || {})[name] = value; }


### PR DESCRIPTION
If you ever use an `identity` attr that gets set to an array or object, then setting a default is clunky because using the `default` prop would result in all instances of the class sharing the same object. This PR makes it possible to use a function to return the default value of a prop, so that each instance can have its own value.

```javascript
this.attr('foos', 'identity', {default: function() { return []; }));
```