### PR TITLE
Don't notify observers unless the value actually changed.

### DIFF
--- a/spec/object_spec.js
+++ b/spec/object_spec.js
@@ -188,6 +188,18 @@ describe('Transis.Object', function() {
         expect(spy).toHaveBeenCalledWith('*');
       });
 
+      it('does not notify observers when the set value is the same as the current value', function() {
+        var spy = jasmine.createSpy();
+
+        t.str = 'xyz';
+        TransisObject.flush();
+
+        t.on('str', spy);
+        t.str = 'xyz';
+        TransisObject.flush();
+        expect(spy).not.toHaveBeenCalled();
+      });
+
       describe('with the readonly option', function() {
         it('generates a readonly property', function() {
           expect(t.ro).toBe(4);

--- a/src/object.js
+++ b/src/object.js
@@ -452,7 +452,9 @@ TransisObject.prototype._setProp = function(name, value) {
   if (descriptor.set) { descriptor.set.call(this, value); }
   else { this[key] = value; }
 
-  this.didChange(name);
+  if (!util.eq(old, this[key])) {
+    this.didChange(name);
+  }
 
   return old;
 };


### PR DESCRIPTION
Currently setting a prop to an equal value notifies observers. This usually leads to unnecessary work being done in the observer. This change simply ensures that the value is actually different before notifying observers.