### PR TITLE
Avoid unnecessarily notifying observers when changes and errors are cleared.

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1228,8 +1228,16 @@ var Model = TransisObject.extend(function() {
   // Internal: Clears validation errors from the `errors` hash. If a name is given, only the errors
   // for the property of that name are cleared, otherwise all errors are cleared.
   this.prototype._clearErrors = function(name) {
-    if (name) { delete this.ownErrors[name]; } else { this.__ownErrors = {}; }
-    this.didChange('ownErrors');
+    if (name) {
+      if (name in this.ownErrors) {
+        delete this.ownErrors[name];
+        this.didChange('ownErrors');
+      }
+    }
+    else if (Object.keys(this.ownErrors).length) {
+      this.__ownErrors = {};
+      this.didChange('ownErrors');
+    }
     return this;
   };
 
@@ -1305,14 +1313,18 @@ var Model = TransisObject.extend(function() {
 
   // Internal: Clears the change record for the property of the given name.
   this.prototype._clearChange = function(name) {
-    delete this.ownChanges[name];
-    this.didChange('ownChanges');
+    if (name in this.ownChanges) {
+      delete this.ownChanges[name];
+      this.didChange('ownChanges');
+    }
   };
 
   // Internal: Clears all change records.
   this.prototype._clearChanges = function() {
-    this.__ownChanges = {};
-    this.didChange('ownChanges');
+    if (Object.keys(this.ownChanges).length) {
+      this.__ownChanges = {};
+      this.didChange('ownChanges');
+    }
   };
 });
 


### PR DESCRIPTION
Currently observers of the `ownChanges` and `ownErrors` props are notified when they are cleared, even if there is nothing there to clear. This PR updates that logic to only notify observers when there is something there to be cleared.