### PR TITLE
React mixin performance enhancement

### DIFF
--- a/spec/object_spec.js
+++ b/spec/object_spec.js
@@ -554,6 +554,29 @@ describe('Transis.Object', function() {
       expect(spy1).toHaveBeenCalled();
       expect(spy2).toHaveBeenCalled();
     });
+
+    it('queues changes made within observer callbacks until the next flush cycle', function() {
+      let t = new Test;
+      let strObserverCalled = false;
+      let defObserverCalled = false;
+
+      t.on('str', function() {
+        strObserverCalled = true;
+        t.def = 'blah';
+      });
+
+      t.on('def', function() {
+        defObserverCalled = true;
+      });
+
+      t.str = 'a';
+
+      TransisObject.flush();
+      expect(strObserverCalled).toBe(true);
+      expect(defObserverCalled).toBe(false);
+      TransisObject.flush();
+      expect(defObserverCalled).toBe(true);
+    });
   });
 
   describe('#notify', function() {

--- a/spec/object_spec.js
+++ b/spec/object_spec.js
@@ -369,24 +369,59 @@ describe('Transis.Object', function() {
     });
   });
 
+  describe('.delayPreFlush', function() {
+    beforeEach(function() {
+      this.calls = [];
+      TransisObject.delayPreFlush(() => {
+        this.calls.push('delay');
+      });
+      this.test = new Test;
+      this.test.on('str', () => {
+        this.calls.push('observer');
+      });
+    });
+
+    it('invokes the given function before the next flush', function() {
+      this.test.str = 'a';
+      TransisObject.flush();
+      expect(this.calls).toEqual(['delay', 'observer']);
+    });
+
+    it('does not invoke the function on subsequent flushes', function() {
+      this.test.str = 'a';
+      TransisObject.flush();
+      expect(this.calls).toEqual(['delay', 'observer']);
+      this.test.str = 'b';
+      TransisObject.flush();
+      expect(this.calls).toEqual(['delay', 'observer', 'observer']);
+    });
+  });
+
   describe('.delay', function() {
     beforeEach(function() {
-      this.spy = jasmine.createSpy();
-      TransisObject.delay(this.spy);
+      this.calls = [];
+      TransisObject.delay(() => {
+        this.calls.push('delay');
+      });
+      this.test = new Test;
+      this.test.on('str', () => {
+        this.calls.push('observer');
+      });
     });
 
     it('invokes the given function after the next flush', function() {
-      expect(this.spy).not.toHaveBeenCalled();
+      this.test.str = 'a';
       TransisObject.flush();
-      expect(this.spy).toHaveBeenCalled();
+      expect(this.calls).toEqual(['observer', 'delay']);
     });
 
-    it('does not invoke the given function on subsequent flushes', function() {
-      expect(this.spy.calls.count()).toBe(0);
+    it('does not invoke the function on subsequent flushes', function() {
+      this.test.str = 'a';
       TransisObject.flush();
-      expect(this.spy.calls.count()).toBe(1);
+      expect(this.calls).toEqual(['observer', 'delay']);
+      this.test.str = 'b';
       TransisObject.flush();
-      expect(this.spy.calls.count()).toBe(1);
+      expect(this.calls).toEqual(['observer', 'delay', 'observer']);
     });
   });
 

--- a/spec/react_spec.js
+++ b/spec/react_spec.js
@@ -38,6 +38,13 @@ describe('PropsMixin', function() {
       TransisObject.flush();
       expect(this.component.forceUpdate).not.toHaveBeenCalled();
     });
+
+    it('attaches observers that only call forceUpdate once per flush cycle', function() {
+      this.model.foo = 1;
+      this.model.bar = 2;
+      TransisObject.flush();
+      expect(this.component.forceUpdate.calls.count()).toBe(1);
+    });
   });
 
   describe('componentWillUnmount', function() {
@@ -135,6 +142,13 @@ describe('StateMixin', function() {
         this.appState.b.foo = 9;
         TransisObject.flush();
         expect(this.component.forceUpdate).toHaveBeenCalled();
+      });
+
+      it('attaches observers that only invoke forceUpdate once per flush cycle', function() {
+        this.appState.b.foo = 9;
+        this.appState.b.bar = 8;
+        TransisObject.flush();
+        expect(this.component.forceUpdate.calls.count()).toBe(1);
       });
 
       it('removes property observers from state property objects when swapped out', function() {

--- a/src/object.js
+++ b/src/object.js
@@ -41,6 +41,11 @@ function TransisObject() {
 
 TransisObject.displayName = 'Transis.Object';
 
+function registerChange(object, prop) {
+  changedObjects[object.objectId] = changedObjects[object.objectId] || {object, props: {}};
+  changedObjects[object.objectId].props[prop] = true;
+}
+
 // Internal: Processes recorded property changes by traversing the property dependency graph and
 // forwarding changes to proxy objects.
 function propagateChanges() {
@@ -61,8 +66,8 @@ function propagateChanges() {
 
     head = head.next;
 
-    changedObjects[objectId] = changedObjects[objectId] || {object, props: {}};
-    changedObjects[objectId].props[name] = true;
+    registerChange(object, name);
+
     if (object.__cache__) { delete object.__cache__[name]; }
 
     if (deps) {
@@ -382,8 +387,7 @@ TransisObject.prototype.notify = function(event, ...args) {
 //
 // Returns the receiver.
 TransisObject.prototype.didChange = function(name) {
-  changedObjects[this.objectId] = changedObjects[this.objectId] || {object: this, props: {}};
-  changedObjects[this.objectId].props[name] = true;
+  registerChange(this, name);
 
   // ensure that observers get triggered after promise callbacks
   if (!flushTimer) { flushTimer = setTimeout(function() { Promise.resolve().then(flush); }); }

--- a/src/react.js
+++ b/src/react.js
@@ -1,21 +1,79 @@
+import TransisObject from "./object";
 import TransisArray from "./array";
+import {getPath} from "./util";
+
+let nextId = 1;
+let updateLog = {};
+let updateQueue = {};
+
+function componentCmp(a, b) {
+  if (a._transisId < b._transisId) { return -1; }
+  else if (a._transisId > b._transisId) { return 1; }
+  else { return 0; }
+}
+
+function preFlush() {
+  updateLog = {};
+  updateQueue = {};
+  TransisObject.delay(postFlush);
+}
+
+function postFlush() {
+  let components = [];
+
+  for (let id in updateQueue) {
+    components.push(updateQueue[id]);
+  }
+
+  // Sort the components by their assigned _transisId. Since components get mounted from the top
+  // down, this should ensure that parent components are force updated before any descendent
+  // components that also need an update. This avoids the case where we force update a component
+  // and then force update one of its ancestors, which may unnecessarily render the component
+  // again.
+  components.sort(componentCmp).forEach(function(component) {
+    if (!updateLog[component._transisId] && component.isMounted()) {
+      component.forceUpdate();
+    }
+  });
+
+  TransisObject.delayPreFlush(preFlush);
+}
+
+function queueUpdate(component) {
+  updateQueue[component._transisId] = component;
+}
+
+function logUpdate(component) {
+  updateLog[component._transisId] = true;
+}
+
+TransisObject.delayPreFlush(preFlush);
 
 export var PropsMixin = function(props) {
   return {
     componentWillMount: function() {
-      this._transisFU = this._transisFU || (() => { this.isMounted() && this.forceUpdate(); });
+      this._transisId = this._transisId || nextId++;
+      this._transisQueueUpdate = this._transisQueueUpdate || (() => { queueUpdate(this); });
 
       for (let k in props) {
         props[k].forEach(function(prop) {
-          if (this.props[k]) { this.props[k].on(prop, this._transisFU); }
+          if (this.props[k]) { this.props[k].on(prop, this._transisQueueUpdate); }
         }, this);
       }
+    },
+
+    componentDidMount: function() {
+      logUpdate(this);
+    },
+
+    componentDidUpdate: function() {
+      logUpdate(this);
     },
 
     componentWillUnmount: function() {
       for (let k in props) {
         props[k].forEach(function(prop) {
-          if (this.props[k]) { this.props[k].off(prop, this._transisFU); }
+          if (this.props[k]) { this.props[k].off(prop, this._transisQueueUpdate); }
         }, this);
       }
     },
@@ -24,8 +82,8 @@ export var PropsMixin = function(props) {
       for (let k in props) {
         props[k].forEach(function(prop) {
           if (nextProps[k] !== this.props[k]) {
-            if (this.props[k]) { this.props[k].off(prop, this._transisFU);  }
-            if (nextProps[k]) { nextProps[k].on(prop, this._transisFU); }
+            if (this.props[k]) { this.props[k].off(prop, this._transisQueueUpdate);  }
+            if (nextProps[k]) { nextProps[k].on(prop, this._transisQueueUpdate); }
           }
         }, this);
       }
@@ -49,7 +107,8 @@ export var StateMixin = function(object, props) {
     },
 
     componentWillMount: function() {
-      this._transisFU = this._transisFU || (() => { this.isMounted() && this.forceUpdate(); });
+      this._transisId = this._transisId || nextId++;
+      this._transisQueueUpdate = this._transisQueueUpdate || (() => { queueUpdate(this); });
 
       this._transisSyncState = () => {
         var state = {};
@@ -57,11 +116,11 @@ export var StateMixin = function(object, props) {
         for (let k in props) {
           if (this.state[k] !== object[k]) {
             if (this.state[k] && typeof this.state[k].off === 'function') {
-              props[k].forEach((path) => { this.state[k].off(path, this._transisFU); });
+              props[k].forEach((path) => { this.state[k].off(path, this._transisQueueUpdate); });
             }
 
             if (object[k] && typeof object[k].on === 'function') {
-              props[k].forEach((path) => { object[k].on(path, this._transisFU); });
+              props[k].forEach((path) => { object[k].on(path, this._transisQueueUpdate); });
             }
 
             state[k] = object[k];
@@ -73,17 +132,25 @@ export var StateMixin = function(object, props) {
 
       for (let k in props) {
         if (object[k] && typeof object[k].on === 'function') {
-          props[k].forEach((path) => { object[k].on(path, this._transisFU); });
+          props[k].forEach((path) => { object[k].on(path, this._transisQueueUpdate); });
         }
       }
 
       object.on('*', this._transisSyncState);
     },
 
+    componentDidMount: function() {
+      logUpdate(this);
+    },
+
+    componentDidUpdate: function() {
+      logUpdate(this);
+    },
+
     componentWillUnmount: function() {
       for (let k in props) {
         if (this.state[k] && typeof this.state[k].off === 'function') {
-          props[k].forEach((path) => { this.state[k].off(path, this._transisFU); });
+          props[k].forEach((path) => { this.state[k].off(path, this._transisQueueUpdate); });
         }
       }
 


### PR DESCRIPTION
This PR updates the React mixins to ensure that `forceUpdate` is only called on a component once per flush cycle. This can lead to significant performance improvements in your React app where you have views that listen for changes to multiple properties that may change at the same time. Special care is also taken to avoid calling `forceUpdate` when a component has already been rendered within the same flush cycle by an ancestor component being updated.

In order to make sure that we properly handle property mutations made within an observer callback, the `flush` logic was also updated to only notify observers of property changes that occur prior to the flush starting. Any changes made within observers will be handled in a subsequent flush cycle. This should properly handle the case where the React mixin forces an update on a component, and then some other observer makes a property change that the component depends on. The component won't get re-rendered in that same flush cycle, but a new one will be queued up where that change will then be rendered.