### PR TITLE
Fix React mixin to handle manual property change notifications

### DIFF
--- a/spec/react_spec.js
+++ b/spec/react_spec.js
@@ -45,6 +45,12 @@ describe('PropsMixin', function() {
       TransisObject.flush();
       expect(this.component.forceUpdate.calls.count()).toBe(1);
     });
+
+    it('handles notifications that occur outside of a flush cycle', function() {
+      this.model.notify('foo');
+      TransisObject.flush();
+      expect(this.component.forceUpdate.calls.count()).toBe(1);
+    });
   });
 
   describe('componentWillUnmount', function() {

--- a/src/react.js
+++ b/src/react.js
@@ -14,7 +14,6 @@ function componentCmp(a, b) {
 
 function preFlush() {
   updateLog = {};
-  updateQueue = {};
   TransisObject.delay(postFlush);
 }
 
@@ -23,6 +22,7 @@ function postFlush() {
 
   for (let id in updateQueue) {
     components.push(updateQueue[id]);
+    delete updateQueue[id];
   }
 
   // Sort the components by their assigned _transisId. Since components get mounted from the top


### PR DESCRIPTION
Notifying a property change manually via the `Transis.Object#notify` method would not trigger an update to a React component observing the prop because the update queue was getting cleared at the beginning of the flush cycle. Notifying a prop change manually happens outside of a flush cycle so the update was never getting processed. The fix was to not clear the update log in the pre-flush callback and instead clear it in the post-flush callback.