### PR TITLE
Adds support for paged query arrays

### DIFF
--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -1096,6 +1096,19 @@ describe('Model', function () {
         });
       });
 
+      it('does not queue the latest call to query when the array is busy and the options are identical to the current query', function(done) {
+        this.a.query({foo: 1});
+        expect(this.a.isBusy).toBe(true);
+        this.a.query({foo: 1});
+        expect(QueryTest.mapper.query.calls.count()).toBe(1);
+        expect(QueryTest.mapper.query).toHaveBeenCalledWith({foo: 1});
+        this.resolve([]);
+        this.delay(() => {
+          expect(QueryTest.mapper.query.calls.count()).toBe(1);
+          done();
+        });
+      });
+
       it('properly resolves the promise when the query is queued', function(done) {
         var spy1 = jasmine.createSpy(), spy2 = jasmine.createSpy();
 

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -913,6 +913,25 @@ describe('Model', function () {
     it('decorates the returned array with a catch method', function() {
       expect(typeof this.a.catch).toBe('function');
     });
+
+    it('decorates the returned array with an isPaged property set to false', function() {
+      expect(this.a.isPaged).toBe(false);
+    });
+
+    it('decorates the returned array with a baseOpts property set to the given options', function() {
+      let a = BasicModel.buildQuery({a: 1, b: 2});
+      expect(a.baseOpts).toEqual({a: 1, b: 2});
+    });
+
+    describe('with a pageSize option', function() {
+      beforeEach(function() {
+        this.a = BasicModel.buildQuery({pageSize: 10});
+      });
+
+      it('decorates the returned array with an isPaged property set to true', function() {
+        expect(this.a.isPaged).toBe(true);
+      });
+    });
   });
 
   describe('query array', function() {
@@ -959,6 +978,19 @@ describe('Model', function () {
         const a = QueryTest.buildQuery({a: 1, b: 2});
         a.query({b: 3, c: 4});
         expect(QueryTest.mapper.query).toHaveBeenCalledWith({a: 1, b: 3, c: 4});
+      });
+
+      it('uses the newly set baseOpts', function(done) {
+        const a = QueryTest.buildQuery({a: 1, b: 2});
+        a.query({b: 3, c: 4});
+        expect(QueryTest.mapper.query).toHaveBeenCalledWith({a: 1, b: 3, c: 4});
+        this.resolve([]);
+        this.delay(() => {
+          a.baseOpts = {a: 10, b: 20};
+          a.query({b: 3, c: 4});
+          expect(QueryTest.mapper.query).toHaveBeenCalledWith({a: 10, b: 3, c: 4});
+          done();
+        });
       });
 
       it('sets the isBusy property', function() {
@@ -1105,6 +1137,82 @@ describe('Model', function () {
         expect(function() {
           Foo.buildQuery().query();
         }).toThrow(new Error("Foo._callMapper: mapper's `query` method did not return a Promise"));
+      });
+
+      describe('with the pageSize option', function() {
+        beforeEach(function() {
+          this.a = QueryTest.buildQuery({pageSize: 3});
+        });
+
+        it('forwards the pageSize option on to the mapper and a default page of 1', function() {
+          this.a.query();
+          expect(QueryTest.mapper.query).toHaveBeenCalledWith({pageSize: 3, page: 1});
+        });
+
+        it('forwards the page option on to the mapper', function() {
+          this.a.query({page: 4});
+          expect(QueryTest.mapper.query).toHaveBeenCalledWith({pageSize: 3, page: 4});
+        });
+
+        it('sets the length of the array to the value of the meta.totalCount value resolved by the mapper', function(done) {
+          expect(this.a.length).toBe(0);
+          this.a.query();
+          this.resolve({meta: {totalCount: 21}, results: [{id: 1}, {id: 2}, {id: 3}]});
+          this.delay(() => {
+            expect(this.a.length).toBe(21);
+            done();
+          });
+        });
+
+        it('splices the results into the array instead of replacing', function(done) {
+          this.a.query();
+          this.resolve({meta: {totalCount: 7}, results: [{id: 1}, {id: 2}, {id: 3}]});
+          this.delay(() => {
+            expect(this.a.length).toBe(7);
+            expect(this.a.map(x => x.id)).toEqual([1, 2, 3, undefined, undefined, undefined, undefined]);
+
+            this.a.query({page: 2});
+            this.resolve({meta: {totalCount: 7}, results: [{id: 4}, {id: 5}, {id: 6}]});
+            this.delay(() => {
+              expect(this.a.length).toBe(7);
+              expect(this.a.map(x => x.id)).toEqual([1, 2, 3, 4, 5, 6, undefined]);
+
+              this.a.query({page: 3});
+              this.resolve({meta: {totalCount: 7}, results: [{id: 7}]});
+              this.delay(() => {
+                expect(this.a.length).toBe(7);
+                expect(this.a.map(x => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+
+                done();
+              });
+            });
+          });
+        });
+
+        it('automatically fetches pages when items are accessed through the #at method', function(done) {
+          expect(this.a.at(0)).toBe(undefined);
+          expect(QueryTest.mapper.query).toHaveBeenCalledWith({pageSize: 3, page: 1});
+          this.resolve({meta: {totalCount: 7}, results: [{id: 1}, {id: 2}, {id: 3}]});
+
+          this.delay(() => {
+            expect(this.a.length).toBe(7);
+            expect(this.a.at(0)).toBe(QueryTest.local(1));
+            expect(this.a.at(1)).toBe(QueryTest.local(2));
+            expect(this.a.at(2)).toBe(QueryTest.local(3));
+
+            expect(this.a.at(3)).toBe(undefined);
+            expect(QueryTest.mapper.query).toHaveBeenCalledWith({pageSize: 3, page: 2});
+            this.resolve({meta: {totalCount: 7}, results: [{id: 4}, {id: 5}, {id: 6}]});
+
+            this.delay(() => {
+              expect(this.a.length).toBe(7);
+              expect(this.a.at(3)).toBe(QueryTest.local(4));
+              expect(this.a.at(4)).toBe(QueryTest.local(5));
+              expect(this.a.at(5)).toBe(QueryTest.local(6));
+              done();
+            });
+          });
+        });
       });
     });
 

--- a/src/model.js
+++ b/src/model.js
@@ -197,32 +197,6 @@ function queryArrayAt(i) {
   return r;
 }
 
-// Internal: Returns a new Transis Array that is decorated with query props and methods. See the
-// documentation for `Model.buildQuery`.
-function queryArray(modelClass, baseOpts = {}) {
-  let a = TransisArray.of();
-
-  a.__modelClass__ = modelClass;
-  a.__promise__ = Promise.resolve();
-
-  a.props({
-    modelClass: {get: function() { return this.__modelClass__; }},
-    baseOpts: {},
-    isBusy: {default: false},
-    isPaged: {on: ['baseOpts'], get: (baseOpts) => typeof baseOpts.pageSize === 'number'},
-    error: {},
-    meta: {}
-  });
-
-  a.baseOpts = baseOpts;
-  a.query = queryArrayQuery;
-  a.then = queryArrayThen;
-  a.catch = queryArrayCatch;
-  a.at = queryArrayAt;
-
-  return a;
-}
-
 // Internal: Sets the given object on a `hasOne` property.
 //
 // desc - An association descriptor.


### PR DESCRIPTION
This PR enhances the `Model.buildQuery` method to return an array that is capable of paging itself. A paged array is a sparse array that knows its full length, but does not yet have all of its elements. When an element is accessed via the `#at` method that the array does not yet have it will automatically go to the mapper to fetch the page the contains that element index. When the mapper resolves its promise with the next page of results, those items are spliced into the array at the appropriate index instead of replacing the contents like a normal query array.

This strategy is designed to work nicely with a virtualized list component. You start by loading the first page of results and then hand that array to the virtualized list component. The virtualized list will only access enough items to fill its viewport, therefore not triggering any additional page loads until the next page of items is scrolled into view by the user. This makes it straightforward to implement a lazily loaded list view.