### PR TITLE
Add support for chained computed prop dependencies

### DIFF
--- a/dist/model.js
+++ b/dist/model.js
@@ -305,10 +305,10 @@ function hasOneSet(desc, v, sync) {
   }
 
   if (prev) {
-    prev._deregisterProxy(this, name);
+    prev.unproxy(this, name);
   }
   if (v) {
-    v._registerProxy(this, name);
+    v.proxy(this, name);
   }
 }
 
@@ -745,7 +745,7 @@ var Model = _object2.default.extend(function () {
   //
   //   When an item is accessed via the `#at` method from a page that has yet to be fetched, the
   //   query array will automatically invoke the mapper to fetch that page. This effectively gives
-  //   you a sparse array that will automatically lazily load its contents when then are needed.
+  //   you a sparse array that will automatically lazily load its contents when they are needed.
   //   This behavior works very well with a virtualized list component.
   //
   //   Here is an example of the object expected from the mapper:

--- a/dist/object.js
+++ b/dist/object.js
@@ -163,7 +163,7 @@ function flush() {
       }
       object.notify(
       // strip '@' suffix if present
-      k.length > 1 && k[k.length - 1] === '@' && k[k.length - 2] !== '.' ? k.slice(0, k.length - 1) : k);
+      k.length > 1 && k.endsWith('@') && !k.endsWith('.@') ? k.slice(0, k.length - 1) : k);
     }
 
     if (star) {

--- a/dist/object.js
+++ b/dist/object.js
@@ -557,10 +557,8 @@ TransisObject.prototype._getProp = function (name) {
   if (desc.cache) {
     this.__cache__ = this.__cache__ || {};
 
-    if (this.__deps__ && this.__deps__[name]) {
-      if (value && typeof value.proxy === 'function') {
-        value.proxy(this, name);
-      }
+    if (this.__deps__ && this.__deps__[name] && value && typeof value.proxy === 'function') {
+      value.proxy(this, name);
     }
 
     this.__cache__[name] = value;

--- a/dist/transis.js
+++ b/dist/transis.js
@@ -284,7 +284,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	      object.notify(
 	      // strip '@' suffix if present
-	      k.length > 1 && k[k.length - 1] === '@' && k[k.length - 2] !== '.' ? k.slice(0, k.length - 1) : k);
+	      k.length > 1 && k.endsWith('@') && !k.endsWith('.@') ? k.slice(0, k.length - 1) : k);
 	    }
 
 	    if (star) {

--- a/dist/transis.js
+++ b/dist/transis.js
@@ -678,10 +678,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  if (desc.cache) {
 	    this.__cache__ = this.__cache__ || {};
 
-	    if (this.__deps__ && this.__deps__[name]) {
-	      if (value && typeof value.proxy === 'function') {
-	        value.proxy(this, name);
-	      }
+	    if (this.__deps__ && this.__deps__[name] && value && typeof value.proxy === 'function') {
+	      value.proxy(this, name);
 	    }
 
 	    this.__cache__[name] = value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transis",
-  "version": "0.11.1",
+  "version": "0.12.0-pre",
   "description": "A javascript data modeling library useful for creating rich client-side experiences.",
   "main": "dist/index.js",
   "repository": "https://github.com/centro/transis.git",

--- a/spec/object_spec.js
+++ b/spec/object_spec.js
@@ -650,4 +650,91 @@ describe('Transis.Object', function() {
       }.bind(this)).not.toThrow();
     });
   });
+
+  describe('#proxy', function() {
+    it('sets up the receiver to proxy notifications to the given proxy object', function() {
+      var t = new Test;
+      var proxy = new TransisObject;
+      var spy = jasmine.createSpy();
+
+      t.proxy(proxy, 'test');
+
+      proxy.on('test.str', spy);
+
+      t.str = 'a';
+      TransisObject.flush();
+
+      expect(spy).toHaveBeenCalledWith('test.str');
+    });
+
+    it('works when multiple proxies are registered', function() {
+      var t = new Test;
+      var proxy1 = new TransisObject;
+      var proxy2 = new TransisObject;
+      var spy1 = jasmine.createSpy();
+      var spy2 = jasmine.createSpy();
+
+      t.proxy(proxy1, 'test');
+      t.proxy(proxy2, 'test');
+
+      proxy1.on('test.str', spy1);
+      proxy2.on('test.str', spy2);
+
+      t.str = 'a';
+      TransisObject.flush();
+
+      expect(spy1).toHaveBeenCalledWith('test.str');
+      expect(spy2).toHaveBeenCalledWith('test.str');
+    });
+  });
+
+  describe('#unproxy', function() {
+    it('removes a previously registered proxy', function() {
+      var t = new Test;
+      var proxy = new TransisObject;
+      var spy = jasmine.createSpy();
+
+      t.proxy(proxy, 'test');
+
+      proxy.on('test.str', spy);
+
+      t.str = 'a';
+      TransisObject.flush();
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      t.unproxy(proxy, 'test');
+
+      t.str = 'b';
+      TransisObject.flush();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('works when multiple proxies are registered', function() {
+      var t = new Test;
+      var proxy1 = new TransisObject;
+      var proxy2 = new TransisObject;
+      var spy1 = jasmine.createSpy();
+      var spy2 = jasmine.createSpy();
+
+      t.proxy(proxy1, 'test');
+      t.proxy(proxy2, 'test');
+
+      proxy1.on('test.str', spy1);
+      proxy2.on('test.str', spy2);
+
+      t.str = 'a';
+      TransisObject.flush();
+
+      expect(spy1).toHaveBeenCalledTimes(1);
+      expect(spy2).toHaveBeenCalledTimes(1);
+
+      t.unproxy(proxy1, 'test');
+
+      t.str = 'b';
+      TransisObject.flush();
+
+      expect(spy1).toHaveBeenCalledTimes(1);
+      expect(spy2).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/array.js
+++ b/src/array.js
@@ -111,20 +111,24 @@ TransisArray.from = function(a, mapFn, thisArg) {
     if (i === 0) { this.didChange('first'); }
     this.didChange('@');
 
-    if (this.__proxy__) {
-      removed.forEach(function(x) {
-        if (x instanceof TransisObject || x instanceof TransisArray) {
-          x.unproxy(this.__proxy__.to, this.__proxy__.name);
-        }
-      }, this);
+    if (this.__proxies__) {
+      for (let k in this.__proxies__) {
+        let {object, name} = this.__proxies__[k];
 
-      added.forEach(function(x) {
-        if (x instanceof TransisObject || x instanceof TransisArray) {
-          x.proxy(this.__proxy__.to, this.__proxy__.name);
-        }
-      }, this);
+        removed.forEach(function(x) {
+          if (x instanceof TransisObject || x instanceof TransisArray) {
+            x.unproxy(object, name);
+          }
+        }, this);
 
-      this.__proxy__.to.didChange(this.__proxy__.name);
+        added.forEach(function(x) {
+          if (x instanceof TransisObject || x instanceof TransisArray) {
+            x.proxy(object, name);
+          }
+        }, this);
+
+        object.didChange(name);
+      }
     }
 
     return TransisArray.from(removed);
@@ -358,9 +362,7 @@ TransisArray.from = function(a, mapFn, thisArg) {
   //
   // Returns the receiver.
   this.prototype.proxy = function(to, name) {
-    if (this.__proxy__) { this.unproxy(); }
-
-    this.__proxy__ = {to, name};
+    TransisObject.prototype.proxy.call(this, to, name);
 
     this.forEach(function(x) {
       if (x instanceof TransisObject || x instanceof TransisArray) {
@@ -371,16 +373,15 @@ TransisArray.from = function(a, mapFn, thisArg) {
     return this;
   };
 
-  // Public: Stop proxying prop changes.
-  this.prototype.unproxy = function() {
-    if (this.__proxy__) {
-      this.forEach(function(x) {
-        if (x instanceof TransisObject || x instanceof TransisArray) {
-          x.unproxy(this.__proxy__.to, this.__proxy__.name);
-        }
-      }, this);
-      delete this.__proxy__;
-    }
+  // Public: Stop proxying prop changes previously set up by `#proxy`.
+  this.prototype.unproxy = function(to, name) {
+    TransisObject.prototype.unproxy.call(this, to, name);
+
+    this.forEach(function(x) {
+      if (x instanceof TransisObject || x instanceof TransisArray) {
+        x.unproxy(to, name);
+      }
+    }, this);
 
     return this;
   };

--- a/src/array.js
+++ b/src/array.js
@@ -113,7 +113,7 @@ TransisArray.from = function(a, mapFn, thisArg) {
 
     if (this.__proxies__) {
       for (let k in this.__proxies__) {
-        let {object, name} = this.__proxies__[k];
+        const {object, name} = this.__proxies__[k];
 
         removed.forEach(function(x) {
           if (x instanceof TransisObject || x instanceof TransisArray) {

--- a/src/array.js
+++ b/src/array.js
@@ -127,7 +127,7 @@ TransisArray.from = function(a, mapFn, thisArg) {
           }
         }, this);
 
-        object.didChange(name);
+        object.didChange(`${name}@`);
       }
     }
 

--- a/src/array.js
+++ b/src/array.js
@@ -114,13 +114,13 @@ TransisArray.from = function(a, mapFn, thisArg) {
     if (this.__proxy__) {
       removed.forEach(function(x) {
         if (x instanceof TransisObject || x instanceof TransisArray) {
-          x._deregisterProxy(this.__proxy__.to, this.__proxy__.name);
+          x.unproxy(this.__proxy__.to, this.__proxy__.name);
         }
       }, this);
 
       added.forEach(function(x) {
         if (x instanceof TransisObject || x instanceof TransisArray) {
-          x._registerProxy(this.__proxy__.to, this.__proxy__.name);
+          x.proxy(this.__proxy__.to, this.__proxy__.name);
         }
       }, this);
 
@@ -364,7 +364,7 @@ TransisArray.from = function(a, mapFn, thisArg) {
 
     this.forEach(function(x) {
       if (x instanceof TransisObject || x instanceof TransisArray) {
-        x._registerProxy(to, name);
+        x.proxy(to, name);
       }
     });
 
@@ -376,7 +376,7 @@ TransisArray.from = function(a, mapFn, thisArg) {
     if (this.__proxy__) {
       this.forEach(function(x) {
         if (x instanceof TransisObject || x instanceof TransisArray) {
-          x._deregisterProxy(this.__proxy__.to, this.__proxy__.name);
+          x.unproxy(this.__proxy__.to, this.__proxy__.name);
         }
       }, this);
       delete this.__proxy__;

--- a/src/model.js
+++ b/src/model.js
@@ -240,8 +240,8 @@ function hasOneSet(desc, v, sync) {
   if (sync && inv && prev) { prev._inverseRemoved(inv, this); }
   if (sync && inv && v) { v._inverseAdded(inv, this); }
 
-  if (prev) { prev._deregisterProxy(this, name); }
-  if (v) { v._registerProxy(this, name); }
+  if (prev) { prev.unproxy(this, name); }
+  if (v) { v.proxy(this, name); }
 }
 
 // Internal: Callback for a successful model deletion. Updates the model's state, removes it from

--- a/src/object.js
+++ b/src/object.js
@@ -417,6 +417,20 @@ TransisObject.prototype.eq = function(other) { return this === other; };
 // Public: Resolves the given path into a value, relative to the receiver. See `util.getPath`.
 TransisObject.prototype.getPath = function(path) { return util.getPath(this, path); };
 
+// Public: Registers a proxy object. All prop changes on the receiver will be proxied to the
+// given proxy object with the given name as a prefix for the property name.
+TransisObject.prototype.proxy = function(object, name) {
+  this.__proxies__ = this.__proxies__ || {};
+  this.__proxies__[`${object.objectId},${name}`] = {object, name};
+  return this;
+};
+
+// Public: Deregisters a proxy object previously registered with `#proxy`.
+TransisObject.prototype.unproxy = function(object, name) {
+  if (this.__proxies__) { delete this.__proxies__[`${object.objectId},${name}`]; }
+  return this;
+};
+
 // Internal: Returns the current value of the given property or the default value if it is not
 // defined.
 //
@@ -477,20 +491,6 @@ TransisObject.prototype._setProp = function(name, value) {
   }
 
   return old;
-};
-
-// Internal: Registers a proxy object. All prop changes on the receiver will be proxied to the
-// given proxy object with the given name as a prefix for the property name.
-TransisObject.prototype._registerProxy = function(object, name) {
-  this.__proxies__ = this.__proxies__ || {};
-  this.__proxies__[`${object.objectId},${name}`] = {object, name};
-  return this;
-};
-
-// Internal: Deregisters a proxy object previously registered with `#_registerProxy`.
-TransisObject.prototype._deregisterProxy = function(object, name) {
-  if (this.__proxies__) { delete this.__proxies__[`${object.objectId},${name}`]; }
-  return this;
 };
 
 TransisObject.displayName = 'Transis.Object';

--- a/src/object.js
+++ b/src/object.js
@@ -130,9 +130,7 @@ function flush() {
       if (k.indexOf('.') === -1) { star = true; }
       object.notify(
         // strip '@' suffix if present
-        k.length > 1 && k[k.length - 1] === '@' && k[k.length - 2] !== '.' ?
-          k.slice(0, k.length - 1) :
-          k
+        k.length > 1 && k.endsWith('@') && !k.endsWith('.@') ? k.slice(0, k.length - 1) : k
       );
     }
 

--- a/src/object.js
+++ b/src/object.js
@@ -476,10 +476,8 @@ TransisObject.prototype._getProp = function(name) {
   if (desc.cache) {
     this.__cache__ = this.__cache__ || {};
 
-    if (this.__deps__ && this.__deps__[name]) {
-      if (value && typeof value.proxy === 'function') {
-        value.proxy(this, name);
-      }
+    if (this.__deps__ && this.__deps__[name] && value && typeof value.proxy === 'function') {
+      value.proxy(this, name);
     }
 
     this.__cache__[name] = value;

--- a/src/object.js
+++ b/src/object.js
@@ -122,7 +122,12 @@ function flush() {
 
     for (let k in props) {
       if (k.indexOf('.') === -1) { star = true; }
-      object.notify(k);
+      object.notify(
+        // strip '@' suffix if present
+        k.length > 1 && k[k.length - 1] === '@' && k[k.length - 2] !== '.' ?
+          k.slice(0, k.length - 1) :
+          k
+      );
     }
 
     if (star) { object.notify('*'); }
@@ -165,11 +170,13 @@ function defineProp(object, name, opts = {}) {
     (object.__deps__[prop] = object.__deps__[prop] || []).push(name);
 
     if (prop.indexOf('.') !== -1) {
-      let segments = prop.split('.'), first = segments[0];
+      let segments = prop.split('.'), first = segments[0], last = segments[1];
       if (segments.length > 2) {
         throw new Error(`Transis.Object.defineProp: dependent property paths of more than two segments are not allowed: \`${prop}\``);
       }
       (object.__deps__[first] = object.__deps__[first] || []).push(name);
+      (object.__deps__[`${first}@`] = object.__deps__[`${first}@`] || []).push(name);
+      (object.__deps__[`${first}.${last}@`] = object.__deps__[`${first}.${last}@`] || []).push(name);
     }
   });
 


### PR DESCRIPTION
`Transis.Model` classes have always supported defining props that depend on properties of associated models. So you could do stuff like this:

```javascript
const Company = Transis.Model.extend('Company', function() {
  this.hasMany('employees', 'Employee');
  this.attr('name', 'string');
});

const Employee = Transis.Model.extend('Employee', function() {
  this.hasOne('company', 'Company');
  this.attr('name', 'string');
  this.attr('salary', 'number');

  this.prop('employerName', {
    cache: true,
    on: ['company.name'],
    get: function(name) { return name; }
  });
});
```

The `Employee#employerName` prop works because associated models automatically proxy prop change notifications to the objects they are associated with.

A common mistake with computed props was to write one that had a chained dependency on the result of another computed prop, like this:

```javascript
const Company = Transis.Model.extend('Company', function() {
  this.hasMany('employees', 'Employee');
  this.attr('name', 'string');

  this.prop('highestPaidEmployee', {
    cache: true,
    on: ['employees', 'employees.salary'],
    get: function(employees) {
      return _.maxBy(employees, 'salary');
    }
  });

  // THIS DID NOT WORK BEFORE
  this.prop('highestPaidEmployeeName', {
    cache: true,
    on: ['hightestPaidEmployee.name'],
    get: function(name) { return name; }
  });
});
```

Previously the `Company#highestPaidEmployeeName` prop could not be observed and its cache would not be maintained properly because `highestPaidEmployee` is not an association and therefore does not proxy its prop changes to the `Company` object. This PR makes these types of props work as you would expect as long as the dependent computed prop returns a Transis object and has `cache: true`.