### PR TITLE
add validation to prop options

### DIFF
--- a/dist/object.js
+++ b/dist/object.js
@@ -176,6 +176,16 @@ function flush() {
   }
 }
 
+var VALID_OPTIONS = ['attr', 'converter', 'name', 'get', 'set', 'default', 'on', 'cache', 'pure'];
+// Internal: Throws error if option is passed that is not used.
+function validateOptions(opts) {
+  Object.getOwnPropertyNames(opts).forEach(function (opt) {
+    if (VALID_OPTIONS.indexOf(opt) < 0) {
+      throw new Error('Transis.Object.defineProp: unknown option `' + opt + '`');
+    }
+  });
+}
+
 // Internal: Indicates whether the current name has a value cached.
 function isCached(name) {
   return this.__cache__ ? this.__cache__.hasOwnProperty(name) : false;
@@ -191,6 +201,8 @@ function getCached(name) {
 // Returns nothing.
 function defineProp(object, name) {
   var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  validateOptions(opts);
 
   var descriptor = Object.assign({
     name: name,

--- a/dist/object.js
+++ b/dist/object.js
@@ -176,14 +176,15 @@ function flush() {
   }
 }
 
-var VALID_OPTIONS = ['attr', 'converter', 'name', 'get', 'set', 'default', 'on', 'cache', 'pure'];
-// Internal: Throws error if option is passed that is not used.
+var VALID_OPTIONS = { attr: 0, converter: 0, name: 0, get: 0, set: 0, default: 0, on: 0, cache: 0, pure: 0 };
+
+// Internal: Throw a warning if option is passed that is not used.
 function validateOptions(opts) {
-  Object.getOwnPropertyNames(opts).forEach(function (opt) {
-    if (VALID_OPTIONS.indexOf(opt) < 0) {
-      throw new Error('Transis.Object.defineProp: unknown option `' + opt + '`');
+  for (var k in opts) {
+    if (!(k in VALID_OPTIONS)) {
+      console.warn('Transis.Object.defineProp: unknown option `' + k + '`');
     }
-  });
+  }
 }
 
 // Internal: Indicates whether the current name has a value cached.

--- a/dist/transis.js
+++ b/dist/transis.js
@@ -297,6 +297,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	}
 
+	var VALID_OPTIONS = { attr: 0, converter: 0, name: 0, get: 0, set: 0, default: 0, on: 0, cache: 0, pure: 0 };
+
+	// Internal: Throw a warning if option is passed that is not used.
+	function validateOptions(opts) {
+	  for (var k in opts) {
+	    if (!(k in VALID_OPTIONS)) {
+	      console.warn('Transis.Object.defineProp: unknown option `' + k + '`');
+	    }
+	  }
+	}
+
 	// Internal: Indicates whether the current name has a value cached.
 	function isCached(name) {
 	  return this.__cache__ ? this.__cache__.hasOwnProperty(name) : false;
@@ -312,6 +323,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	// Returns nothing.
 	function defineProp(object, name) {
 	  var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+	  validateOptions(opts);
 
 	  var descriptor = Object.assign({
 	    name: name,

--- a/spec/object_spec.js
+++ b/spec/object_spec.js
@@ -539,6 +539,14 @@ describe('Transis.Object', function() {
       expect('x' in new Test).toBe(false);
     });
 
+    it('Throws an error if the option provided is unknown', function() {
+      expect(function() {
+        TransisObject.extend(function() {
+          this.prop('x', { foo: true, on: ['bar'], get: function() {}});
+        });
+      }).toThrow(new Error('Transis.Object.defineProp: unknown option `foo`'));
+    });
+
     it('notifies observers when changed', function() {
       var spy = jasmine.createSpy();
 

--- a/spec/object_spec.js
+++ b/spec/object_spec.js
@@ -539,12 +539,11 @@ describe('Transis.Object', function() {
       expect('x' in new Test).toBe(false);
     });
 
-    it('Throws an error if the option provided is unknown', function() {
-      expect(function() {
-        TransisObject.extend(function() {
-          this.prop('x', { foo: true, on: ['bar'], get: function() {}});
-        });
-      }).toThrow(new Error('Transis.Object.defineProp: unknown option `foo`'));
+    describe('with an uknown option', function() {
+      it('thows a warning message if in non production environment', function() {
+        TransisObject.extend(function() { this.prop('x', { foo: true }); });
+        expect(console.warn).toHaveBeenCalledWith('Transis.Object.defineProp: unknown option `foo`');
+      });
     });
 
     it('notifies observers when changed', function() {

--- a/src/object.js
+++ b/src/object.js
@@ -140,14 +140,15 @@ function flush() {
   while ((f = delayPostFlushCallbacks.shift())) { f(); }
 }
 
-var VALID_OPTIONS = ['attr', 'converter', 'name', 'get', 'set', 'default', 'on', 'cache', 'pure'];
-// Internal: Throws error if option is passed that is not used.
+const VALID_OPTIONS = { attr: 0, converter: 0, name: 0, get: 0, set: 0, default: 0, on: 0, cache: 0, pure: 0 };
+
+// Internal: Throw a warning if option is passed that is not used.
 function validateOptions(opts) {
-  Object.getOwnPropertyNames(opts).forEach(function(opt) {
-    if(VALID_OPTIONS.indexOf(opt) < 0) {
-      throw new Error(`Transis.Object.defineProp: unknown option \`${opt}\``);
+  for (let k in opts) {
+    if(!(k in VALID_OPTIONS)) {
+      console.warn(`Transis.Object.defineProp: unknown option \`${k}\``);
     }
-  });
+  }
 }
 
 // Internal: Indicates whether the current name has a value cached.

--- a/src/object.js
+++ b/src/object.js
@@ -140,6 +140,16 @@ function flush() {
   while ((f = delayPostFlushCallbacks.shift())) { f(); }
 }
 
+var VALID_OPTIONS = ['attr', 'converter', 'name', 'get', 'set', 'default', 'on', 'cache', 'pure'];
+// Internal: Throws error if option is passed that is not used.
+function validateOptions(opts) {
+  Object.getOwnPropertyNames(opts).forEach(function(opt) {
+    if(VALID_OPTIONS.indexOf(opt) < 0) {
+      throw new Error(`Transis.Object.defineProp: unknown option \`${opt}\``);
+    }
+  });
+}
+
 // Internal: Indicates whether the current name has a value cached.
 function isCached(name) { return this.__cache__ ? this.__cache__.hasOwnProperty(name) : false; }
 
@@ -150,6 +160,8 @@ function getCached(name) { return this.__cache__ ? this.__cache__[name] : undefi
 //
 // Returns nothing.
 function defineProp(object, name, opts = {}) {
+  validateOptions(opts);
+
   var descriptor = Object.assign({
     name: name,
     get: null,


### PR DESCRIPTION
First pass at adding some code to let the user know the option they passed for creating a `prop` is not going to be used.

Throwing an error might be too heavy handed.