### PR TITLE
Feature - adds Array#reset(initialArray : Array, meta: Object)

### DIFF
--- a/dist/model.js
+++ b/dist/model.js
@@ -279,6 +279,20 @@ function queryArrayAt(i) {
   return r;
 }
 
+// Internal: Provides the implementation of the query array to empty and then refill its content and update its `meta`.
+function queryArrayReset() {
+  var newInitialArray = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+  var meta = arguments[1];
+
+  this.replace(newInitialArray);
+  this.meta = meta;
+  if (meta && meta.totalCount) {
+    this.length = meta.totalCount;
+  }
+  this.error = undefined;
+  return this;
+};
+
 // Internal: Sets the given object on a `hasOne` property.
 //
 // desc - An association descriptor.
@@ -748,6 +762,9 @@ var Model = _object2.default.extend(function () {
   //   you a sparse array that will automatically lazily load its contents when they are needed.
   //   This behavior works very well with a virtualized list component.
   //
+  //   `reset`: A function to be invoked to empty, refill and update the metadata on the
+  //   query array.
+  //
   //   Here is an example of the object expected from the mapper:
   //
   //   {
@@ -813,6 +830,7 @@ var Model = _object2.default.extend(function () {
     a.then = queryArrayThen;
     a.catch = queryArrayCatch;
     a.at = queryArrayAt;
+    a.reset = queryArrayReset;
 
     return a;
   };

--- a/dist/transis.js
+++ b/dist/transis.js
@@ -1831,6 +1831,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return r;
 	}
 
+	// Internal: Provides the implementation of the query array to empty and then refill its content and update its `meta`.
+	function queryArrayReset() {
+	  var newInitialArray = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+	  var meta = arguments[1];
+
+	  this.replace(newInitialArray);
+	  this.meta = meta;
+	  if (meta && meta.totalCount) {
+	    this.length = meta.totalCount;
+	  }
+	  this.error = undefined;
+	  return this;
+	};
+
 	// Internal: Sets the given object on a `hasOne` property.
 	//
 	// desc - An association descriptor.
@@ -2300,6 +2314,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  //   you a sparse array that will automatically lazily load its contents when they are needed.
 	  //   This behavior works very well with a virtualized list component.
 	  //
+	  //   `reset`: A function to be invoked to empty, refill and update the metadata on the
+	  //   query array.
+	  //
 	  //   Here is an example of the object expected from the mapper:
 	  //
 	  //   {
@@ -2365,6 +2382,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    a.then = queryArrayThen;
 	    a.catch = queryArrayCatch;
 	    a.at = queryArrayAt;
+	    a.reset = queryArrayReset;
 
 	    return a;
 	  };

--- a/spec/model_spec.js
+++ b/spec/model_spec.js
@@ -1015,6 +1015,45 @@ describe('Model', function () {
         expect(this.a.isPaged).toBe(true);
       });
     });
+
+    describe('QueryArray#reset', function() {
+      var a1;
+      var meta = { totalCount: 4 };
+      beforeEach(function() {
+        a1 = BasicModel.buildQuery({ pageSize: 4 });
+        a1.meta = { foo: 'bar' };
+        a1.error = "error occured"
+      });
+
+      it('clears error', function() {
+        a1.reset();
+        expect(a1.error).toBe(undefined);
+      });
+
+      it('clears meta if no meta is given', function() {
+        a1.reset([6, 7]);
+        expect(a1.meta).toBe(undefined);
+      });
+
+      it('return an empty array if no initial array is given', function() {
+        a1.reset();
+        expect(a1).toEqual([]);
+      });
+
+      describe('given new initial array and meta', function() {
+        beforeEach(function() {
+          a1.reset([6, 7], meta);
+        });
+
+        it('clears the existing array and set the new items', function() {
+          expect(a1).toEqual([6, 7, undefined, undefined]);
+        });
+
+        it('sets the `meta` on the instance', function() {
+          expect(a1.meta).toEqual(meta);
+        });
+      });
+    });
   });
 
   describe('query array', function() {

--- a/src/model.js
+++ b/src/model.js
@@ -222,6 +222,17 @@ function queryArrayAt(i) {
   return r;
 }
 
+// Internal: Provides the implementation of the query array to empty and then refill its content and update its `meta`.
+function queryArrayReset(newInitialArray = [], meta) {
+  this.replace(newInitialArray);
+  this.meta = meta;
+  if (meta && meta.totalCount) {
+    this.length = meta.totalCount;
+  }
+  this.error = undefined;
+  return this;
+};
+
 // Internal: Sets the given object on a `hasOne` property.
 //
 // desc - An association descriptor.
@@ -637,6 +648,9 @@ var Model = TransisObject.extend(function() {
   //   you a sparse array that will automatically lazily load its contents when they are needed.
   //   This behavior works very well with a virtualized list component.
   //
+  //   `reset`: A function to be invoked to empty, refill and update the metadata on the
+  //   query array.
+  //
   //   Here is an example of the object expected from the mapper:
   //
   //   {
@@ -696,6 +710,7 @@ var Model = TransisObject.extend(function() {
     a.then = queryArrayThen;
     a.catch = queryArrayCatch;
     a.at = queryArrayAt;
+    a.reset = queryArrayReset;
 
     return a;
   };


### PR DESCRIPTION
Currently a `Query` object cannot easily reset and refill itself if we want to manually update its content and meta. To achieve the manual modification, we currently need to perform the following on the `Query`/`TransisArray` object:

```javascript
    query.clear();
    query.replace(newArray);
    query.length = response.data.meta.totalCount; // make sparse on the array.
    query.meta = response.data.meta;
```
This PR seeks to internalize this abstraction.