### PR TITLE
[attrs] Don't rely on toJSON/string-parsing on DateAttr serialization

### DIFF
--- a/dist/attrs.js
+++ b/dist/attrs.js
@@ -96,6 +96,10 @@ var BooleanAttr = exports.BooleanAttr = {
   }
 };
 
+function format2Digits(num) {
+  return num < 10 ? '0' + num : num;
+}
+
 var DateAttr = exports.DateAttr = {
   coerce: function coerce(v) {
     if (v == null || v instanceof Date) {
@@ -112,7 +116,11 @@ var DateAttr = exports.DateAttr = {
     return parsers.parseDate(v);
   },
   serialize: function serialize(date) {
-    return date instanceof Date ? date.toJSON().replace(/T.*$/, '') : date;
+    if (date instanceof Date) {
+      return date.getFullYear() + '-' + format2Digits(date.getMonth() + 1) + '-' + format2Digits(date.getDate());
+    } else {
+      return date;
+    }
   }
 };
 

--- a/src/attrs.js
+++ b/src/attrs.js
@@ -47,6 +47,10 @@ export var BooleanAttr = {
   serialize(b) { return b; }
 };
 
+function format2Digits(num) {
+  return num < 10 ? `0${num}` : num;
+}
+
 export var DateAttr = {
   coerce(v) {
     if (v == null || v instanceof Date) { return v; }
@@ -60,7 +64,13 @@ export var DateAttr = {
   },
 
   serialize(date) {
-    return date instanceof Date ? date.toJSON().replace(/T.*$/, '') : date;
+    if (date instanceof Date) {
+      return date.getFullYear() + '-'
+        + format2Digits(date.getMonth() + 1) + '-'
+        + format2Digits(date.getDate());
+    } else {
+      return date;
+    }
   }
 };
 


### PR DESCRIPTION
Relying on `Date.prototype.toJSON()` and string manipulation is causing the incorrect date to be serialized...

<img width="431" alt="screen shot 2018-09-26 at 11 44 30 am" src="https://user-images.githubusercontent.com/284734/46101644-21210c00-c192-11e8-9cd0-b8f83d2b9d15.png">
